### PR TITLE
Fix original SCPH-1200 controller: setup delay after select

### DIFF
--- a/emu/crates/emulator-core/src/bus.rs
+++ b/emu/crates/emulator-core/src/bus.rs
@@ -445,6 +445,13 @@ impl Bus {
         self.sio0.set_port1_buttons(buttons);
     }
 
+    /// Enable/disable the slow original-controller (SCPH-1200) timing model on
+    /// SIO0. When on, a guest poll that clocks bytes without waiting for each
+    /// `/ACK` pulse desyncs, reproducing the hardware failure headlessly.
+    pub fn set_slow_pad(&mut self, slow: bool) {
+        self.sio0.set_slow_pad(slow);
+    }
+
     /// Update the analog-stick positions on the port-1
     /// controller. Each axis is `0..=255` with `0x80` = centre.
     /// No-op when no pad is attached to port 1. The stick values

--- a/emu/crates/emulator-core/src/sio.rs
+++ b/emu/crates/emulator-core/src/sio.rs
@@ -126,6 +126,17 @@ pub struct Sio0 {
     /// transitions (deselect → select) to reset device state
     /// machines, matching hardware.
     last_joyn: bool,
+    /// Opt-in: model a slow original controller (e.g. SCPH-1200) that only
+    /// becomes ready for the next byte once it has pulsed `/ACK`. A host that
+    /// clocks the next byte without waiting for that pulse desyncs the packet.
+    /// Off by default; the idealized fast pad above is what normal runs use.
+    slow_pad: bool,
+    /// While `slow_pad`: the cycle the device is ready for the next byte (the
+    /// current byte's `/ACK` deadline). `None` between transactions.
+    slow_ready_cycle: Option<u64>,
+    /// While `slow_pad`: set once a byte was clocked before the device was
+    /// ready; the rest of the packet then returns `0xFF` until deselect.
+    slow_desynced: bool,
 }
 
 impl Sio0 {
@@ -163,6 +174,21 @@ impl Sio0 {
                 .with_memcard(crate::pad::MemoryCard::new()),
             port2: crate::pad::PortDevice::empty().with_memcard(crate::pad::MemoryCard::new()),
             last_joyn: false,
+            slow_pad: false,
+            slow_ready_cycle: None,
+            slow_desynced: false,
+        }
+    }
+
+    /// Enable or disable the slow original-controller timing model. When on, a
+    /// poll that does not wait for each byte's `/ACK` pulse desyncs, reproducing
+    /// an SCPH-1200 against a host that clocks bytes back-to-back. Used by the
+    /// regression test and the `--slow-pad` headless flag.
+    pub fn set_slow_pad(&mut self, slow: bool) {
+        self.slow_pad = slow;
+        if !slow {
+            self.slow_ready_cycle = None;
+            self.slow_desynced = false;
         }
     }
 
@@ -456,19 +482,34 @@ impl Sio0 {
         }
         let (rx, ack, _device_present, ack_delay_ticks) = if self.ctrl & ctrl_bit::JOYN_OUTPUT != 0
         {
-            let port = self.active_port();
-            let result = port.exchange_detailed_at(value, now);
-            let ack_delay_ticks = if port.selected_is_memcard() {
-                MEMCARD_ACK_DELAY_TICKS
+            // Slow original-controller timing: a byte clocked before the
+            // previous byte's `/ACK` deadline arrives while the device is still
+            // busy, so it misses the clock and the rest of the packet desyncs.
+            if self.slow_pad {
+                if self.slow_ready_cycle.is_some_and(|ready| now < ready) {
+                    self.slow_desynced = true;
+                }
+                self.slow_ready_cycle = Some(now.saturating_add(self.transfer_ticks()));
+            }
+            if self.slow_pad && self.slow_desynced {
+                // The device missed the clock; it returns idle and does not
+                // advance its state machine.
+                (0xFF, false, true, PAD_ACK_DELAY_TICKS)
             } else {
-                PAD_ACK_DELAY_TICKS
-            };
-            (
-                result.rx,
-                result.ack,
-                result.device_present,
-                ack_delay_ticks,
-            )
+                let port = self.active_port();
+                let result = port.exchange_detailed_at(value, now);
+                let ack_delay_ticks = if port.selected_is_memcard() {
+                    MEMCARD_ACK_DELAY_TICKS
+                } else {
+                    PAD_ACK_DELAY_TICKS
+                };
+                (
+                    result.rx,
+                    result.ack,
+                    result.device_present,
+                    ack_delay_ticks,
+                )
+            }
         } else {
             (0xFF, false, true, PAD_ACK_DELAY_TICKS)
         };
@@ -525,6 +566,9 @@ impl Sio0 {
             self.port1.deselect();
             self.port2.deselect();
             self.last_joyn = false;
+            // Keep the slow-pad opt-in, drop its per-transaction state.
+            self.slow_ready_cycle = None;
+            self.slow_desynced = false;
             return;
         }
         if value & ctrl_bit::ACK != 0 {
@@ -551,6 +595,9 @@ impl Sio0 {
             self.ack_end_deadline = None;
             self.port1.deselect();
             self.port2.deselect();
+            // A fresh select starts a clean packet for the slow-pad model.
+            self.slow_ready_cycle = None;
+            self.slow_desynced = false;
         }
         self.last_joyn = new_joyn;
         self.ctrl = new_ctrl;
@@ -1093,6 +1140,68 @@ mod tests {
             Some(11 + DEFAULT_TRANSFER_TICKS),
             "new synchronous byte should replace the next delayed IRQ deadline"
         );
+    }
+
+    #[test]
+    fn slow_pad_desyncs_without_ack_wait() {
+        use crate::pad::{button, ButtonState, DigitalPad, PortDevice};
+
+        let mut sio = Sio0::new();
+        sio.attach_port1(PortDevice::empty().with_pad(DigitalPad::new()));
+        sio.set_port1_buttons(ButtonState::from_bits(button::START));
+        sio.set_slow_pad(true);
+        sio.write16(Sio0::BASE + 0xE, 0x0088); // baud -> transfer_ticks = 1088
+        sio.write16(Sio0::BASE + 0xA, ctrl_bit::JOYN_OUTPUT); // select port 1
+
+        let mut now = 100u64;
+        // The select byte is always fine (no prior /ACK deadline to beat).
+        sio.write8_at(Sio0::BASE, 0x01, now);
+        assert_eq!(sio.pop_rx(), 0xFF);
+
+        // The command byte is clocked only a few cycles later -- long before the
+        // slow pad's /ACK deadline (now + 1088) -- so the device misses it.
+        now += 8;
+        sio.write8_at(Sio0::BASE, 0x42, now);
+        assert_eq!(
+            sio.pop_rx(),
+            0xFF,
+            "a slow pad must not return its 0x41 id when the host skips the /ACK wait"
+        );
+
+        // Every subsequent byte of the packet stays desynced.
+        now += 8;
+        sio.write8_at(Sio0::BASE, 0x00, now);
+        assert_eq!(sio.pop_rx(), 0xFF, "packet remains desynced after a missed byte");
+    }
+
+    #[test]
+    fn slow_pad_reads_clean_with_ack_wait() {
+        use crate::pad::{button, ButtonState, DigitalPad, PortDevice};
+
+        let mut sio = Sio0::new();
+        sio.attach_port1(PortDevice::empty().with_pad(DigitalPad::new()));
+        sio.set_port1_buttons(ButtonState::from_bits(button::START | button::CROSS));
+        sio.set_slow_pad(true);
+        sio.write16(Sio0::BASE + 0xE, 0x0088);
+        sio.write16(Sio0::BASE + 0xA, ctrl_bit::JOYN_OUTPUT);
+
+        // Mirror the ACK-paced driver: wait past each byte's /ACK deadline
+        // (transfer_ticks = 0x88 * 8 = 1088) before clocking the next byte.
+        let gap = 0x88u64 * 8 + 16;
+        let mut now = 100u64;
+        let mut ex = |sio: &mut Sio0, now: &mut u64, tx: u8| -> u8 {
+            sio.write8_at(Sio0::BASE, tx, *now);
+            sio.tick(*now);
+            let rx = sio.read8(Sio0::BASE).unwrap();
+            *now += gap; // host waited for /ACK before clocking the next byte
+            rx
+        };
+
+        assert_eq!(ex(&mut sio, &mut now, 0x01), 0xFF);
+        assert_eq!(ex(&mut sio, &mut now, 0x42), 0x41, "id after /ACK wait");
+        assert_eq!(ex(&mut sio, &mut now, 0x00), 0x5A, "magic after /ACK wait");
+        assert_eq!(ex(&mut sio, &mut now, 0x00), 0xF7, "buttons1 (START)");
+        assert_eq!(ex(&mut sio, &mut now, 0x00), 0xBF, "buttons2 (CROSS)");
     }
 
     #[test]

--- a/emu/crates/frontend/src/cli.rs
+++ b/emu/crates/frontend/src/cli.rs
@@ -172,6 +172,12 @@ pub struct LaunchArgs {
     /// SYSTEM.CNF fast boot.
     #[arg(long)]
     pub bios_boot: bool,
+    /// Model a slow original controller (SCPH-1200) on SIO0: a guest poll that
+    /// clocks bytes without waiting for each `/ACK` pulse desyncs, reproducing
+    /// the hardware failure headlessly. Pair with the controller-probe disc to
+    /// see the no-wait column go DESYNC while the ACK-paced column stays clean.
+    #[arg(long)]
+    pub slow_pad: bool,
     /// Print an FNV-1a-64 VRAM hash at the end. Same algorithm the
     /// milestone regression tests use, so a CLI run + a unit test
     /// should produce identical numbers.
@@ -727,6 +733,10 @@ fn run_headless_launch(
             return Err(format!("unsupported file extension: .{other}"));
         }
     };
+
+    if args.slow_pad {
+        bus.set_slow_pad(true);
+    }
 
     let mut held_button_mask = 0u16;
     if args.hold_forward || args.hold_run {
@@ -1817,6 +1827,7 @@ fn validation_launch_args(
         pad_pulses: None,
         embedded_playtest: artifact.embedded_playtest,
         bios_boot: artifact.bios_boot,
+        slow_pad: false,
         dump_hash: false,
         guest_debug_log: false,
         visual_hash_log: None,

--- a/engine/examples/hardware-tests/src/main.rs
+++ b/engine/examples/hardware-tests/src/main.rs
@@ -37,9 +37,9 @@ const FONT_TPAGE: Tpage = Tpage::new(320, 0, TexDepth::Bit4);
 const FONT_CLUT: Clut = Clut::new(320, 256);
 
 const ROWS_PER_PAGE: usize = 6;
-const TEST_COUNT: usize = 170;
+const TEST_COUNT: usize = 173;
 const PAD_POLL_TEST_INDEX: usize = 26;
-const MODE_COUNT: u8 = 15;
+const MODE_COUNT: u8 = 16;
 const CHECK_MODES: [Mode; 11] = [
     Mode::AllChecks,
     Mode::CpuChecks,
@@ -86,6 +86,7 @@ enum Status {
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 enum Mode {
+    ControllerProbe,
     AllChecks,
     CpuChecks,
     MemoryChecks,
@@ -106,6 +107,7 @@ enum Mode {
 impl Mode {
     const fn label(self) -> &'static str {
         match self {
+            Self::ControllerProbe => "CONTROLLER PROBE",
             Self::AllChecks => "ALL CHECKS",
             Self::CpuChecks => "CPU CHECKS",
             Self::MemoryChecks => "RAM CHECKS",
@@ -126,6 +128,7 @@ impl Mode {
 
     const fn hint(self) -> &'static str {
         match self {
+            Self::ControllerProbe => "DOWN=TESTS  NO PAD NEEDED TO READ THIS",
             Self::AllChecks
             | Self::CpuChecks
             | Self::MemoryChecks
@@ -146,6 +149,7 @@ impl Mode {
 
     const fn description(self) -> &'static str {
         match self {
+            Self::ControllerProbe => "RAW PAD HANDSHAKE: NO-WAIT VS ACK-WAIT",
             Self::AllChecks => "ALL STABLE PASS/FAIL CHECKS",
             Self::CpuChecks => "CPU INSTRUCTIONS AND MEMORY ACCESS",
             Self::MemoryChecks => "RAM KSEG AND SCRATCHPAD CHECKS",
@@ -166,6 +170,7 @@ impl Mode {
 
     const fn aux_label(self) -> &'static str {
         match self {
+            Self::ControllerProbe => "ACK",
             Self::AllChecks
             | Self::CpuChecks
             | Self::MemoryChecks
@@ -186,40 +191,42 @@ impl Mode {
 
     const fn index(self) -> u8 {
         match self {
-            Self::AllChecks => 0,
-            Self::CpuChecks => 1,
-            Self::MemoryChecks => 2,
-            Self::IrqChecks => 3,
-            Self::DmaChecks => 4,
-            Self::TimerChecks => 5,
-            Self::GpuChecks => 6,
-            Self::GteChecks => 7,
-            Self::SpuChecks => 8,
-            Self::CdromChecks => 9,
-            Self::SioChecks => 10,
-            Self::CpuScan => 11,
-            Self::GteScan => 12,
-            Self::SpuScan => 13,
-            Self::TimingScan => 14,
+            Self::ControllerProbe => 0,
+            Self::AllChecks => 1,
+            Self::CpuChecks => 2,
+            Self::MemoryChecks => 3,
+            Self::IrqChecks => 4,
+            Self::DmaChecks => 5,
+            Self::TimerChecks => 6,
+            Self::GpuChecks => 7,
+            Self::GteChecks => 8,
+            Self::SpuChecks => 9,
+            Self::CdromChecks => 10,
+            Self::SioChecks => 11,
+            Self::CpuScan => 12,
+            Self::GteScan => 13,
+            Self::SpuScan => 14,
+            Self::TimingScan => 15,
         }
     }
 
     const fn from_index(index: u8) -> Self {
         match index % MODE_COUNT {
-            0 => Self::AllChecks,
-            1 => Self::CpuChecks,
-            2 => Self::MemoryChecks,
-            3 => Self::IrqChecks,
-            4 => Self::DmaChecks,
-            5 => Self::TimerChecks,
-            6 => Self::GpuChecks,
-            7 => Self::GteChecks,
-            8 => Self::SpuChecks,
-            9 => Self::CdromChecks,
-            10 => Self::SioChecks,
-            11 => Self::CpuScan,
-            12 => Self::GteScan,
-            13 => Self::SpuScan,
+            0 => Self::ControllerProbe,
+            1 => Self::AllChecks,
+            2 => Self::CpuChecks,
+            3 => Self::MemoryChecks,
+            4 => Self::IrqChecks,
+            5 => Self::DmaChecks,
+            6 => Self::TimerChecks,
+            7 => Self::GpuChecks,
+            8 => Self::GteChecks,
+            9 => Self::SpuChecks,
+            10 => Self::CdromChecks,
+            11 => Self::SioChecks,
+            12 => Self::CpuScan,
+            13 => Self::GteScan,
+            14 => Self::SpuScan,
             _ => Self::TimingScan,
         }
     }
@@ -1262,6 +1269,21 @@ const TESTS: [TestSpec; TEST_COUNT] = [
         name: "mask bit on CPU->VRAM copy",
         run: test_gpu_cpu_vram_upload_mask,
     },
+    TestSpec {
+        group: "SIO",
+        name: "port 1 handshake strict (ack-paced)",
+        run: test_pad_handshake_strict,
+    },
+    TestSpec {
+        group: "SIO",
+        name: "port 1 /ACK observed each byte",
+        run: test_pad_ack_observed,
+    },
+    TestSpec {
+        group: "SIO",
+        name: "DualShock analog enable handshake",
+        run: test_pad_analog_handshake,
+    },
 ];
 
 struct HardwareTests {
@@ -1278,6 +1300,11 @@ struct HardwareTests {
     info_count: u8,
     page: usize,
     rerun_count: u8,
+    /// Latest raw port-1 poll using the hardware-correct ACK-paced timing.
+    probe_ack: psx_pad::RawPoll,
+    /// Latest raw port-1 poll using the legacy no-wait timing (reproduces the
+    /// slow-original-controller failure for side-by-side comparison).
+    probe_nowait: psx_pad::RawPoll,
 }
 
 #[cfg(target_arch = "mips")]
@@ -1304,7 +1331,9 @@ impl HardwareTests {
     const fn new() -> Self {
         Self {
             font: None,
-            mode: Mode::AllChecks,
+            // Boot straight into the controller probe: it needs no pad input to
+            // read, so a non-working controller can still be diagnosed.
+            mode: Mode::ControllerProbe,
             results: [TestResult::pending(); TEST_COUNT],
             cpu_scan: ScanReport::pending("press x to sweep"),
             gte_scan: ScanReport::pending("press x to sweep"),
@@ -1316,6 +1345,8 @@ impl HardwareTests {
             info_count: 0,
             page: 0,
             rerun_count: 0,
+            probe_ack: psx_pad::RawPoll::NONE,
+            probe_nowait: psx_pad::RawPoll::NONE,
         }
     }
 
@@ -1418,6 +1449,15 @@ impl Scene for HardwareTests {
         self.results[PAD_POLL_TEST_INDEX] = pad_poll_result(ctx.pad);
         self.recount();
 
+        if matches!(self.mode, Mode::ControllerProbe) {
+            // Refresh both timings so the probe shows the legacy no-wait failure
+            // next to the ACK-paced fix. Polled on the update tick (not render)
+            // to keep all SIO traffic on one clock. Each poll selects/deselects
+            // independently, so the two are isolated.
+            self.probe_ack = psx_pad::poll_port1_raw(psx_pad::Pacing::AckWait);
+            self.probe_nowait = psx_pad::poll_port1_raw(psx_pad::Pacing::NoAckWait);
+        }
+
         if ctx.just_pressed(button::UP) {
             self.mode = self.mode.previous();
             self.page = 0;
@@ -1457,6 +1497,7 @@ impl Scene for HardwareTests {
             draw_problem_detail(font, self, self.mode);
         } else {
             match self.mode {
+                Mode::ControllerProbe => draw_controller_probe(font, self),
                 Mode::CpuScan => draw_scan_report(font, self.mode, self.cpu_scan),
                 Mode::GteScan => draw_scan_report(font, self.mode, self.gte_scan),
                 Mode::SpuScan => draw_scan_report(font, self.mode, self.spu_scan),
@@ -1705,6 +1746,154 @@ fn draw_case_diagnostic_pass(
         drawn += 1;
     }
     drawn
+}
+
+/// The boot screen: poll port 1 two ways and show the raw handshake so a
+/// controller can be diagnosed with no working controller needed to navigate.
+/// Column A uses the legacy no-wait timing (which desyncs slow original pads);
+/// column B uses the `/ACK`-paced timing the SDK now ships. On an SCPH-1200 the
+/// two columns disagree (A garbage, B clean); on a fast clone or in the emulator
+/// they agree.
+fn draw_controller_probe(font: &FontAtlas, suite: &HardwareTests) {
+    font.draw_text(8, 30, "PORT 1 RAW HANDSHAKE", (232, 236, 244));
+    font.draw_text(8, 42, "A=LEGACY NO-WAIT  B=/ACK-PACED FIX", (150, 170, 200));
+
+    font.draw_text(8, 58, "A: NO-WAIT", (220, 190, 120));
+    font.draw_text(168, 58, "B: ACK-WAIT", (140, 210, 160));
+
+    draw_probe_column(font, 8, suite.probe_nowait, false);
+    draw_probe_column(font, 168, suite.probe_ack, true);
+
+    let present =
+        suite.probe_ack.mode.is_connected() || suite.probe_nowait.mode.is_connected();
+    let aok = probe_column_ok(suite.probe_ack);
+    let nwok = probe_column_ok(suite.probe_nowait);
+    let (msg, color) = if !present {
+        ("NO PAD ON PORT 1 - CHECK CABLE/PORT", Status::Warn.color())
+    } else if aok && !nwok {
+        ("SLOW PAD: NEEDS ACK PACING - FIX OK", Status::Pass.color())
+    } else if aok && nwok {
+        ("PAD OK ON BOTH TIMINGS", Status::Pass.color())
+    } else if !aok && nwok {
+        ("REGRESSION: ACK BROKE A NO-WAIT PAD", Status::Fail.color())
+    } else {
+        ("PAD ANSWERS BUT HANDSHAKE UNSTABLE", Status::Fail.color())
+    };
+    font.draw_text(8, 168, "VERDICT", (140, 160, 190));
+    font.draw_text(8, 180, msg, color);
+    font.draw_text(8, 200, "ANALOG LED ON => MODE 73 EXPECTED", (112, 136, 170));
+    font.draw_text(8, 212, "RERUNS LIVE. DOWN = TEST DASHBOARD", (150, 170, 200));
+}
+
+/// Draw one timing column of the controller probe at horizontal origin `x`.
+fn draw_probe_column(font: &FontAtlas, x: i16, raw: psx_pad::RawPoll, ack_paced: bool) {
+    let ok = probe_column_ok(raw);
+    let ok_color = if ok {
+        Status::Pass.color()
+    } else {
+        Status::Fail.color()
+    };
+    let label = (150, 170, 200);
+    let val = (224, 228, 234);
+    let bad = Status::Fail.color();
+
+    font.draw_text(x, 72, "ID", label);
+    font.draw_text(
+        x + 40,
+        72,
+        hex2(raw.id_high).as_str(),
+        if raw.id_high == 0x5A { val } else { bad },
+    );
+    font.draw_text(x + 56, 72, hex2(raw.id_low).as_str(), val);
+
+    font.draw_text(x, 84, "MODE", label);
+    font.draw_text(x + 40, 84, mode_text(raw.mode), ok_color);
+
+    font.draw_text(x, 96, "BTN", label);
+    font.draw_text(x + 40, 96, hex2(raw.buttons_low).as_str(), val);
+    font.draw_text(x + 56, 96, hex2(raw.buttons_high).as_str(), val);
+
+    font.draw_text(x, 108, "LXY", label);
+    font.draw_text(x + 40, 108, hex2(raw.sticks.left_x).as_str(), val);
+    font.draw_text(x + 56, 108, hex2(raw.sticks.left_y).as_str(), val);
+
+    font.draw_text(x, 120, "RXY", label);
+    font.draw_text(x + 40, 120, hex2(raw.sticks.right_x).as_str(), val);
+    font.draw_text(x + 56, 120, hex2(raw.sticks.right_y).as_str(), val);
+
+    font.draw_text(x, 132, "ACK", label);
+    if ack_paced {
+        font.draw_text(x + 40, 132, ack_frac(raw).as_str(), val);
+    } else {
+        font.draw_text(x + 40, 132, "n/a", (120, 130, 150));
+    }
+
+    font.draw_text(x, 144, "RES", label);
+    let res = if !raw.mode.is_connected() {
+        "NO PAD"
+    } else if ok {
+        "CLEAN"
+    } else {
+        "DESYNC"
+    };
+    font.draw_text(x + 40, 144, res, ok_color);
+}
+
+/// A column is clean when something answered with a valid 0x5A magic and a
+/// classified mode (not the `Unknown` desync bucket).
+fn probe_column_ok(raw: psx_pad::RawPoll) -> bool {
+    raw.mode.is_connected()
+        && !matches!(raw.mode, psx_pad::PadMode::Unknown)
+        && raw.id_high == 0x5A
+}
+
+const fn mode_text(mode: psx_pad::PadMode) -> &'static str {
+    match mode {
+        psx_pad::PadMode::Digital => "DIGITAL 41",
+        psx_pad::PadMode::Analog => "ANALOG 73",
+        psx_pad::PadMode::Config => "CONFIG F3",
+        psx_pad::PadMode::Unknown => "UNKNOWN",
+        psx_pad::PadMode::Disconnected => "NONE",
+    }
+}
+
+struct Hex2 {
+    bytes: [u8; 2],
+}
+
+impl Hex2 {
+    fn as_str(&self) -> &str {
+        unsafe { core::str::from_utf8_unchecked(&self.bytes) }
+    }
+}
+
+fn hex2(value: u8) -> Hex2 {
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+    Hex2 {
+        bytes: [HEX[(value >> 4) as usize], HEX[(value & 0xF) as usize]],
+    }
+}
+
+struct AckFrac {
+    bytes: [u8; 3],
+}
+
+impl AckFrac {
+    fn as_str(&self) -> &str {
+        unsafe { core::str::from_utf8_unchecked(&self.bytes) }
+    }
+}
+
+/// "acked/needed" -- how many of the bytes that should have been acknowledged
+/// actually were. The final packet byte is never acknowledged, so `needed` is
+/// `exchanges - 1`.
+fn ack_frac(raw: psx_pad::RawPoll) -> AckFrac {
+    let needed = raw.exchanges.saturating_sub(1);
+    let mask = (1u16 << needed.min(15)).wrapping_sub(1);
+    let acked = (raw.ack_seen & mask).count_ones() as u8;
+    AckFrac {
+        bytes: [b'0' + acked.min(9), b'/', b'0' + needed.min(9)],
+    }
 }
 
 fn test_count_for_mode(mode: Mode) -> usize {
@@ -4176,6 +4365,65 @@ fn pad_poll_result(pad: psx_engine::PadState) -> TestResult {
         TestResult::info(1, pad.id_low as u32, "connected")
     } else {
         TestResult::info(0, 0, "optional")
+    }
+}
+
+/// Strict port-1 handshake under the shipping ACK-paced timing: a connected
+/// controller must answer with the 0x5A magic and a classified mode. A desync
+/// (wrong magic / Unknown mode) is a hard FAIL, not the old benign "optional".
+/// An empty port stays optional -- absence is not a failure.
+fn test_pad_handshake_strict() -> TestResult {
+    let raw = psx_pad::poll_port1_raw(psx_pad::Pacing::AckWait);
+    let observed = ((raw.id_high as u32) << 8) | raw.id_low as u32;
+    if !raw.mode.is_connected() {
+        return TestResult::info(0, observed, "optional");
+    }
+    if raw.id_high == 0x5A && !matches!(raw.mode, psx_pad::PadMode::Unknown) {
+        TestResult::pass(0x5A41, observed, "clean")
+    } else {
+        TestResult::fail(0x5A41, observed, "desync")
+    }
+}
+
+/// The connected controller should pull `/ACK` low for every non-final byte
+/// under the ACK-paced timing. PASS when every expected ACK was seen; WARN when
+/// a pad answers but is not acknowledging (reading blind -- the SCPH-1200
+/// failure mode that the legacy no-wait path papered over). Empty port stays
+/// optional. `observed` packs acked count (hi byte) and needed count (lo byte).
+fn test_pad_ack_observed() -> TestResult {
+    let raw = psx_pad::poll_port1_raw(psx_pad::Pacing::AckWait);
+    let needed = raw.exchanges.saturating_sub(1);
+    let mask = (1u16 << needed.min(15)).wrapping_sub(1);
+    let acked = (raw.ack_seen & mask).count_ones();
+    let observed = ((acked) << 8) | needed as u32;
+    if !raw.mode.is_connected() {
+        return TestResult::info(0, observed, "optional");
+    }
+    if raw.ack_complete() {
+        TestResult::pass(needed as u32, observed, "acks ok")
+    } else {
+        TestResult::warn(needed as u32, observed, "no ack")
+    }
+}
+
+/// DualShock analog handshake: request analog mode via the same ACK-paced config
+/// transaction games use, then confirm the pad reports ID 0x73 with stick bytes.
+/// A digital-only pad is INFO, not a failure; an empty port is optional.
+fn test_pad_analog_handshake() -> TestResult {
+    if !psx_pad::poll_port1().is_connected() {
+        return TestResult::info(0, 0, "optional");
+    }
+    let became_analog = psx_pad::enable_analog_port1();
+    let raw = psx_pad::poll_port1_raw(psx_pad::Pacing::AckWait);
+    let observed = ((raw.id_low as u32) << 16)
+        | ((raw.sticks.left_x as u32) << 8)
+        | raw.sticks.left_y as u32;
+    if became_analog && raw.id_low == 0x73 {
+        TestResult::pass(0x73, observed, "analog")
+    } else if raw.mode.is_connected() {
+        TestResult::info(raw.id_low as u32, observed, "digital-only")
+    } else {
+        TestResult::warn(0x73, observed, "lost pad")
     }
 }
 

--- a/engine/examples/hardware-tests/src/main.rs
+++ b/engine/examples/hardware-tests/src/main.rs
@@ -39,6 +39,20 @@ const FONT_CLUT: Clut = Clut::new(320, 256);
 const ROWS_PER_PAGE: usize = 6;
 const TEST_COUNT: usize = 173;
 const PAD_POLL_TEST_INDEX: usize = 26;
+
+/// Number of timing variants the controller probe sweeps.
+const PROBE_VARIANT_COUNT: usize = 5;
+/// `(label, setup_spins, interbyte_spins)` the controller probe tries each frame
+/// to find what timing a strict original pad (SCPH-1200) needs. `setup_spins` is
+/// a delay after asserting the select line; `interbyte_spins` is a fixed gap
+/// after each byte. Both are bounded STAT reads, no `/ACK`/CTRL machinery.
+const PROBE_VARIANTS: [(&str, u32, u32); PROBE_VARIANT_COUNT] = [
+    ("SETUP 0", 0, 0),
+    ("SETUP 128", 128, 0),
+    ("SETUP 384", 384, 0),
+    ("SETUP 768", 768, 0),
+    ("SETUP 2K", 2048, 0),
+];
 const MODE_COUNT: u8 = 16;
 const CHECK_MODES: [Mode; 11] = [
     Mode::AllChecks,
@@ -1271,13 +1285,13 @@ const TESTS: [TestSpec; TEST_COUNT] = [
     },
     TestSpec {
         group: "SIO",
-        name: "port 1 handshake strict (ack-paced)",
+        name: "port 1 handshake strict (no-wait)",
         run: test_pad_handshake_strict,
     },
     TestSpec {
         group: "SIO",
-        name: "port 1 /ACK observed each byte",
-        run: test_pad_ack_observed,
+        name: "port 1 diag setup+inter timing",
+        run: test_pad_diag_timing,
     },
     TestSpec {
         group: "SIO",
@@ -1300,11 +1314,10 @@ struct HardwareTests {
     info_count: u8,
     page: usize,
     rerun_count: u8,
-    /// Latest raw port-1 poll using the hardware-correct ACK-paced timing.
-    probe_ack: psx_pad::RawPoll,
-    /// Latest raw port-1 poll using the legacy no-wait timing (reproduces the
-    /// slow-original-controller failure for side-by-side comparison).
-    probe_nowait: psx_pad::RawPoll,
+    /// Latest port-1 poll for each [`PROBE_VARIANTS`] timing, refreshed every
+    /// frame while in the controller probe. Used to find which setup/inter-byte
+    /// timing wakes a strict original pad.
+    probe_variants: [psx_pad::RawPoll; PROBE_VARIANT_COUNT],
 }
 
 #[cfg(target_arch = "mips")]
@@ -1345,8 +1358,7 @@ impl HardwareTests {
             info_count: 0,
             page: 0,
             rerun_count: 0,
-            probe_ack: psx_pad::RawPoll::NONE,
-            probe_nowait: psx_pad::RawPoll::NONE,
+            probe_variants: [psx_pad::RawPoll::NONE; PROBE_VARIANT_COUNT],
         }
     }
 
@@ -1450,12 +1462,16 @@ impl Scene for HardwareTests {
         self.recount();
 
         if matches!(self.mode, Mode::ControllerProbe) {
-            // Refresh both timings so the probe shows the legacy no-wait failure
-            // next to the ACK-paced fix. Polled on the update tick (not render)
-            // to keep all SIO traffic on one clock. Each poll selects/deselects
-            // independently, so the two are isolated.
-            self.probe_ack = psx_pad::poll_port1_raw(psx_pad::Pacing::AckWait);
-            self.probe_nowait = psx_pad::poll_port1_raw(psx_pad::Pacing::NoAckWait);
+            // Sweep every timing variant once per frame. Each poll selects and
+            // deselects independently, so the variants stay isolated; the strict
+            // original pad either wakes up for some setup/inter-byte timing or it
+            // does not, and we see exactly which.
+            let mut i = 0;
+            while i < PROBE_VARIANT_COUNT {
+                let (_, setup, interbyte) = PROBE_VARIANTS[i];
+                self.probe_variants[i] = psx_pad::poll_port1_diag(setup, interbyte);
+                i += 1;
+            }
         }
 
         if ctx.just_pressed(button::UP) {
@@ -1484,6 +1500,11 @@ impl Scene for HardwareTests {
 
     fn render(&mut self, ctx: &mut Ctx) {
         draw_test_pattern(ctx.sim_tick.as_u32());
+        // GPU line liveness cross only on the GPU section -- keeps the controller
+        // probe and other focused screens clean.
+        if matches!(self.mode, Mode::GpuChecks) {
+            draw_gpu_line_probe();
+        }
 
         let Some(font) = self.font.as_ref() else {
             return;
@@ -1755,91 +1776,84 @@ fn draw_case_diagnostic_pass(
 /// two columns disagree (A garbage, B clean); on a fast clone or in the emulator
 /// they agree.
 fn draw_controller_probe(font: &FontAtlas, suite: &HardwareTests) {
-    font.draw_text(8, 30, "PORT 1 RAW HANDSHAKE", (232, 236, 244));
-    font.draw_text(8, 42, "A=LEGACY NO-WAIT  B=/ACK-PACED FIX", (150, 170, 200));
+    font.draw_text(8, 30, "PORT 1 SETUP-DELAY SWEEP", (232, 236, 244));
+    font.draw_text(8, 42, "MIN SELECT SETUP THE PAD NEEDS (FIX=2K)", (150, 170, 200));
 
-    font.draw_text(8, 58, "A: NO-WAIT", (220, 190, 120));
-    font.draw_text(168, 58, "B: ACK-WAIT", (140, 210, 160));
+    let hdr = (140, 160, 190);
+    font.draw_text(8, 58, "VARIANT", hdr);
+    font.draw_text(112, 58, "ID", hdr);
+    font.draw_text(160, 58, "MOD", hdr);
+    font.draw_text(200, 58, "BTN", hdr);
+    font.draw_text(248, 58, "RES", hdr);
 
-    draw_probe_column(font, 8, suite.probe_nowait, false);
-    draw_probe_column(font, 168, suite.probe_ack, true);
+    let base_ok = probe_column_ok(suite.probe_variants[0]);
+    let mut woke: Option<&'static str> = None;
+    let mut any_present = false;
 
-    let present =
-        suite.probe_ack.mode.is_connected() || suite.probe_nowait.mode.is_connected();
-    let aok = probe_column_ok(suite.probe_ack);
-    let nwok = probe_column_ok(suite.probe_nowait);
-    let (msg, color) = if !present {
-        ("NO PAD ON PORT 1 - CHECK CABLE/PORT", Status::Warn.color())
-    } else if aok && !nwok {
-        ("SLOW PAD: NEEDS ACK PACING - FIX OK", Status::Pass.color())
-    } else if aok && nwok {
-        ("PAD OK ON BOTH TIMINGS", Status::Pass.color())
-    } else if !aok && nwok {
-        ("REGRESSION: ACK BROKE A NO-WAIT PAD", Status::Fail.color())
-    } else {
-        ("PAD ANSWERS BUT HANDSHAKE UNSTABLE", Status::Fail.color())
-    };
-    font.draw_text(8, 168, "VERDICT", (140, 160, 190));
-    font.draw_text(8, 180, msg, color);
-    font.draw_text(8, 200, "ANALOG LED ON => MODE 73 EXPECTED", (112, 136, 170));
-    font.draw_text(8, 212, "RERUNS LIVE. DOWN = TEST DASHBOARD", (150, 170, 200));
-}
+    let mut i = 0usize;
+    while i < PROBE_VARIANT_COUNT {
+        let (label, _, _) = PROBE_VARIANTS[i];
+        let raw = suite.probe_variants[i];
+        let ok = probe_column_ok(raw);
+        let connected = raw.mode.is_connected();
+        any_present |= connected;
+        let y = 72 + i as i16 * 16;
+        let color = if ok {
+            Status::Pass.color()
+        } else if connected {
+            Status::Fail.color()
+        } else {
+            (130, 140, 160)
+        };
 
-/// Draw one timing column of the controller probe at horizontal origin `x`.
-fn draw_probe_column(font: &FontAtlas, x: i16, raw: psx_pad::RawPoll, ack_paced: bool) {
-    let ok = probe_column_ok(raw);
-    let ok_color = if ok {
-        Status::Pass.color()
-    } else {
-        Status::Fail.color()
-    };
-    let label = (150, 170, 200);
-    let val = (224, 228, 234);
-    let bad = Status::Fail.color();
+        font.draw_text(8, y, label, (220, 224, 230));
+        font.draw_text(
+            112,
+            y,
+            hex2(raw.id_high).as_str(),
+            if raw.id_high == 0x5A {
+                (224, 228, 234)
+            } else {
+                color
+            },
+        );
+        font.draw_text(128, y, hex2(raw.id_low).as_str(), color);
+        font.draw_text(160, y, mode_short(raw.mode), color);
+        font.draw_text(200, y, hex2(raw.buttons_low).as_str(), (200, 206, 214));
+        font.draw_text(216, y, hex2(raw.buttons_high).as_str(), (200, 206, 214));
+        let res = if !connected {
+            "NOPAD"
+        } else if ok {
+            "CLEAN"
+        } else {
+            "DSYNC"
+        };
+        font.draw_text(248, y, res, color);
 
-    font.draw_text(x, 72, "ID", label);
-    font.draw_text(
-        x + 40,
-        72,
-        hex2(raw.id_high).as_str(),
-        if raw.id_high == 0x5A { val } else { bad },
-    );
-    font.draw_text(x + 56, 72, hex2(raw.id_low).as_str(), val);
-
-    font.draw_text(x, 84, "MODE", label);
-    font.draw_text(x + 40, 84, mode_text(raw.mode), ok_color);
-
-    font.draw_text(x, 96, "BTN", label);
-    font.draw_text(x + 40, 96, hex2(raw.buttons_low).as_str(), val);
-    font.draw_text(x + 56, 96, hex2(raw.buttons_high).as_str(), val);
-
-    font.draw_text(x, 108, "LXY", label);
-    font.draw_text(x + 40, 108, hex2(raw.sticks.left_x).as_str(), val);
-    font.draw_text(x + 56, 108, hex2(raw.sticks.left_y).as_str(), val);
-
-    font.draw_text(x, 120, "RXY", label);
-    font.draw_text(x + 40, 120, hex2(raw.sticks.right_x).as_str(), val);
-    font.draw_text(x + 56, 120, hex2(raw.sticks.right_y).as_str(), val);
-
-    font.draw_text(x, 132, "ACK", label);
-    if ack_paced {
-        font.draw_text(x + 40, 132, ack_frac(raw).as_str(), val);
-    } else {
-        font.draw_text(x + 40, 132, "n/a", (120, 130, 150));
+        // First clean variant that the base (old no-wait) timing did NOT get is
+        // the timing the strict pad needs.
+        if ok && !base_ok && woke.is_none() {
+            woke = Some(label);
+        }
+        i += 1;
     }
 
-    font.draw_text(x, 144, "RES", label);
-    let res = if !raw.mode.is_connected() {
-        "NO PAD"
-    } else if ok {
-        "CLEAN"
+    font.draw_text(8, 168, "VERDICT", (140, 160, 190));
+    if let Some(label) = woke {
+        font.draw_text(8, 180, "OFFICIAL PAD NEEDS:", Status::Pass.color());
+        font.draw_text(160, 180, label, Status::Pass.color());
+    } else if base_ok {
+        font.draw_text(8, 180, "PAD WORKS AT BASE TIMING (CLONE)", Status::Pass.color());
+    } else if any_present {
+        font.draw_text(8, 180, "ANSWERS BUT NO VARIANT CLEAN", Status::Warn.color());
     } else {
-        "DESYNC"
-    };
-    font.draw_text(x + 40, 144, res, ok_color);
+        font.draw_text(8, 180, "NO PAD - ALL VARIANTS DEAD", Status::Warn.color());
+    }
+    font.draw_text(8, 200, "BASE = OLD NO-WAIT. RERUNS LIVE.", (112, 136, 170));
+    font.draw_text(8, 212, "DOWN = TEST DASHBOARD", (150, 170, 200));
 }
 
-/// A column is clean when something answered with a valid 0x5A magic and a
+/// A poll is clean when something answered with a valid 0x5A magic and a
 /// classified mode (not the `Unknown` desync bucket).
 fn probe_column_ok(raw: psx_pad::RawPoll) -> bool {
     raw.mode.is_connected()
@@ -1847,13 +1861,13 @@ fn probe_column_ok(raw: psx_pad::RawPoll) -> bool {
         && raw.id_high == 0x5A
 }
 
-const fn mode_text(mode: psx_pad::PadMode) -> &'static str {
+const fn mode_short(mode: psx_pad::PadMode) -> &'static str {
     match mode {
-        psx_pad::PadMode::Digital => "DIGITAL 41",
-        psx_pad::PadMode::Analog => "ANALOG 73",
-        psx_pad::PadMode::Config => "CONFIG F3",
-        psx_pad::PadMode::Unknown => "UNKNOWN",
-        psx_pad::PadMode::Disconnected => "NONE",
+        psx_pad::PadMode::Digital => "DIG",
+        psx_pad::PadMode::Analog => "ANA",
+        psx_pad::PadMode::Config => "CFG",
+        psx_pad::PadMode::Unknown => "UNK",
+        psx_pad::PadMode::Disconnected => "---",
     }
 }
 
@@ -1871,28 +1885,6 @@ fn hex2(value: u8) -> Hex2 {
     const HEX: &[u8; 16] = b"0123456789ABCDEF";
     Hex2 {
         bytes: [HEX[(value >> 4) as usize], HEX[(value & 0xF) as usize]],
-    }
-}
-
-struct AckFrac {
-    bytes: [u8; 3],
-}
-
-impl AckFrac {
-    fn as_str(&self) -> &str {
-        unsafe { core::str::from_utf8_unchecked(&self.bytes) }
-    }
-}
-
-/// "acked/needed" -- how many of the bytes that should have been acknowledged
-/// actually were. The final packet byte is never acknowledged, so `needed` is
-/// `exchanges - 1`.
-fn ack_frac(raw: psx_pad::RawPoll) -> AckFrac {
-    let needed = raw.exchanges.saturating_sub(1);
-    let mask = (1u16 << needed.min(15)).wrapping_sub(1);
-    let acked = (raw.ack_seen & mask).count_ones() as u8;
-    AckFrac {
-        bytes: [b'0' + acked.min(9), b'/', b'0' + needed.min(9)],
     }
 }
 
@@ -2256,6 +2248,12 @@ fn draw_test_pattern(_tick: u32) {
     gpu::draw_quad_flat([(0, 188), (320, 188), (0, 240), (320, 240)], 8, 12, 28);
     gpu::draw_line_mono(0, 48, 319, 48, 60, 80, 110);
     gpu::draw_line_mono(0, 187, 319, 187, 60, 80, 110);
+}
+
+/// GPU monochrome-line liveness check: a red and a blue diagonal crossing in a
+/// small box. Only shown on the GPU section now (it is cosmetic -- the GPU draw
+/// tests assert the real line behaviour), so the focused screens stay clean.
+fn draw_gpu_line_probe() {
     gpu::draw_line_mono(272, 50, 312, 90, 255, 80, 80);
     gpu::draw_line_mono(312, 50, 272, 90, 80, 180, 255);
 }
@@ -4368,12 +4366,12 @@ fn pad_poll_result(pad: psx_engine::PadState) -> TestResult {
     }
 }
 
-/// Strict port-1 handshake under the shipping ACK-paced timing: a connected
+/// Strict port-1 handshake under the shipping no-wait timing: a connected
 /// controller must answer with the 0x5A magic and a classified mode. A desync
 /// (wrong magic / Unknown mode) is a hard FAIL, not the old benign "optional".
 /// An empty port stays optional -- absence is not a failure.
 fn test_pad_handshake_strict() -> TestResult {
-    let raw = psx_pad::poll_port1_raw(psx_pad::Pacing::AckWait);
+    let raw = psx_pad::poll_port1_diag(psx_pad::DEFAULT_SETUP_SPINS, 0);
     let observed = ((raw.id_high as u32) << 8) | raw.id_low as u32;
     if !raw.mode.is_connected() {
         return TestResult::info(0, observed, "optional");
@@ -4385,36 +4383,32 @@ fn test_pad_handshake_strict() -> TestResult {
     }
 }
 
-/// The connected controller should pull `/ACK` low for every non-final byte
-/// under the ACK-paced timing. PASS when every expected ACK was seen; WARN when
-/// a pad answers but is not acknowledging (reading blind -- the SCPH-1200
-/// failure mode that the legacy no-wait path papered over). Empty port stays
-/// optional. `observed` packs acked count (hi byte) and needed count (lo byte).
-fn test_pad_ack_observed() -> TestResult {
-    let raw = psx_pad::poll_port1_raw(psx_pad::Pacing::AckWait);
-    let needed = raw.exchanges.saturating_sub(1);
-    let mask = (1u16 << needed.min(15)).wrapping_sub(1);
-    let acked = (raw.ack_seen & mask).count_ones();
-    let observed = ((acked) << 8) | needed as u32;
+/// The fixed setup+inter-byte diagnostic timing must read a connected pad as
+/// cleanly as the base no-wait timing (it is the same no-wait exchange plus
+/// fixed delays, no `/ACK`/CTRL machinery). PASS clean, WARN if a connected pad
+/// desyncs under the delays, optional when nothing is plugged in.
+fn test_pad_diag_timing() -> TestResult {
+    let raw = psx_pad::poll_port1_diag(2048, 2048);
+    let observed = ((raw.id_high as u32) << 8) | raw.id_low as u32;
     if !raw.mode.is_connected() {
         return TestResult::info(0, observed, "optional");
     }
-    if raw.ack_complete() {
-        TestResult::pass(needed as u32, observed, "acks ok")
+    if raw.id_high == 0x5A && !matches!(raw.mode, psx_pad::PadMode::Unknown) {
+        TestResult::pass(0x5A41, observed, "clean")
     } else {
-        TestResult::warn(needed as u32, observed, "no ack")
+        TestResult::warn(0x5A41, observed, "diag desync")
     }
 }
 
-/// DualShock analog handshake: request analog mode via the same ACK-paced config
-/// transaction games use, then confirm the pad reports ID 0x73 with stick bytes.
-/// A digital-only pad is INFO, not a failure; an empty port is optional.
+/// DualShock analog handshake: request analog mode via the config transaction
+/// games use, then confirm the pad reports ID 0x73 with stick bytes. A
+/// digital-only pad is INFO, not a failure; an empty port is optional.
 fn test_pad_analog_handshake() -> TestResult {
     if !psx_pad::poll_port1().is_connected() {
         return TestResult::info(0, 0, "optional");
     }
     let became_analog = psx_pad::enable_analog_port1();
-    let raw = psx_pad::poll_port1_raw(psx_pad::Pacing::AckWait);
+    let raw = psx_pad::poll_port1_diag(psx_pad::DEFAULT_SETUP_SPINS, 0);
     let observed = ((raw.id_low as u32) << 16)
         | ((raw.sticks.left_x as u32) << 8)
         | raw.sticks.left_y as u32;

--- a/sdk/crates/psx-pad/src/lib.rs
+++ b/sdk/crates/psx-pad/src/lib.rs
@@ -224,16 +224,119 @@ impl PadState {
     }
 }
 
+/// How a transaction paces its bytes across the serial link.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Pacing {
+    /// Wait only for the RX FIFO between bytes; never wait for `/ACK`. This is
+    /// the legacy timing: it works with fast (often third-party) controllers and
+    /// in emulation, but desyncs slower original units (e.g. SCPH-1200) that
+    /// pull `/ACK` low later. Exposed so a diagnostic can reproduce the failure
+    /// side-by-side with [`Pacing::AckWait`].
+    NoAckWait,
+    /// Wait for the device's `/ACK` (DSR) pulse after each non-final byte before
+    /// clocking the next one. Hardware-correct and universally compatible; this
+    /// is what [`poll_port1`] and the analog-enable handshake use.
+    AckWait,
+}
+
+/// Raw wire result of one poll, before active-low button inversion. Carries the
+/// per-byte `/ACK` observations so a diagnostic can show whether the controller
+/// acknowledges each byte, and which pacing produced a clean handshake.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct RawPoll {
+    /// ID low byte: 0x41 digital, 0x73 analog, 0xF3 config, 0xFF none.
+    pub id_low: u8,
+    /// ID high byte; 0x5A on a valid controller, anything else is a desync.
+    pub id_high: u8,
+    /// First button byte, raw active-low wire value.
+    pub buttons_low: u8,
+    /// Second button byte, raw active-low wire value.
+    pub buttons_high: u8,
+    /// Raw stick bytes (centre 0x80) when the controller reports them.
+    pub sticks: AnalogSticks,
+    /// Mode inferred from the ID bytes (`Unknown` when the 0x5A magic is wrong).
+    pub mode: PadMode,
+    /// Bit `i` set if exchange `i` observed an `/ACK` pulse (bit 0 = select byte).
+    pub ack_seen: u16,
+    /// Number of exchanges performed (select byte + payload bytes).
+    pub exchanges: u8,
+}
+
+impl RawPoll {
+    /// A poll where nothing answered (id_low `0xFF`). Useful as a const seed.
+    pub const NONE: Self = Self::disconnected(0xFF);
+
+    /// A poll where nothing answered.
+    const fn disconnected(id_low: u8) -> Self {
+        Self {
+            id_low,
+            id_high: 0xFF,
+            buttons_low: 0xFF,
+            buttons_high: 0xFF,
+            sticks: AnalogSticks::CENTERED,
+            mode: PadMode::Disconnected,
+            ack_seen: 0,
+            exchanges: 0,
+        }
+    }
+
+    /// `true` when every payload exchange that should have been acknowledged
+    /// was. The select byte (bit 0) and all bytes up to (but not including) the
+    /// final, never-acknowledged byte must each show an `/ACK`.
+    #[inline]
+    pub fn ack_complete(self) -> bool {
+        if self.exchanges < 2 {
+            return false;
+        }
+        // The last exchange is the final packet byte; the device does not ACK
+        // it. Every earlier exchange must have been acknowledged.
+        let acked_needed = self.exchanges - 1;
+        let mask = (1u16 << acked_needed) - 1;
+        self.ack_seen & mask == mask
+    }
+
+    /// Convert to the cleaned [`PadState`] used by game code.
+    pub fn to_state(self) -> PadState {
+        PadState {
+            buttons: decode_buttons(self.buttons_low, self.buttons_high),
+            mode: self.mode,
+            sticks: self.sticks,
+            id_low: self.id_low,
+        }
+    }
+}
+
 // --- SIO0 CTRL bits we care about ---
 
 const CTRL_TXEN: u16 = 1 << 0;
 const CTRL_JOYN: u16 = 1 << 1;
 const CTRL_RXEN: u16 = 1 << 2;
+/// Write-1 to acknowledge / clear the latched SIO IRQ (STAT bit 9).
 const CTRL_ACK: u16 = 1 << 4;
+/// Enable IRQ7 generation from the device `/ACK` (DSR) pulse. We never take the
+/// CPU interrupt -- the controller source stays masked in `I_MASK` (the runtime
+/// only unmasks VBlank) -- but enabling it is what latches `STAT` bit 9 on the
+/// `/ACK` edge, so a brief pulse cannot be missed by polling.
+const CTRL_ACK_IRQ_EN: u16 = 1 << 12;
 const CTRL_SLOT_PORT2: u16 = 1 << 13;
+
+// --- SIO0 STAT bits we care about ---
+
+const STAT_TX_READY: u32 = 1 << 0;
+const STAT_RX_NOT_EMPTY: u32 = 1 << 1;
+/// Live `/ACK` (DSR) input level: 1 while the device holds `/ACK` asserted.
+const STAT_DSR_LEVEL: u32 = 1 << 7;
+/// Latched DSR/ACK interrupt: set on the `/ACK` edge, held until CTRL.ACK clears it.
+const STAT_IRQ: u32 = 1 << 9;
+
 const MODE_8N1: u16 = 0x000D;
 const BAUD_PAD: u16 = 0x0088;
+/// Spin budget waiting for the byte shift itself (TX-ready / RX-not-empty).
 const EXCHANGE_WAIT_SPINS: u32 = 32_768;
+/// Spin budget waiting for the `/ACK` pulse. Comfortably exceeds the kernel's
+/// ~100us DSR timeout on hardware and the emulator's ~1k-cycle ACK deadline,
+/// so a genuinely slow original controller is still given time to answer.
+const ACK_WAIT_SPINS: u32 = 2_048;
 
 /// Poll the controller in port 1 once.
 ///
@@ -249,6 +352,19 @@ pub fn poll_port1() -> PadState {
 /// analog mode it also contains the four DualShock stick bytes.
 pub fn poll_port2() -> PadState {
     poll_state(true)
+}
+
+/// Poll port 1 once and return the raw wire bytes plus `/ACK` observations,
+/// using the requested [`Pacing`]. Intended for diagnostics that want to show
+/// the unfiltered handshake (or reproduce the legacy [`Pacing::NoAckWait`]
+/// failure); normal game code should use [`poll_port1`].
+pub fn poll_port1_raw(pacing: Pacing) -> RawPoll {
+    unsafe { poll_once_raw(false, pacing) }
+}
+
+/// Port-2 counterpart of [`poll_port1_raw`].
+pub fn poll_port2_raw(pacing: Pacing) -> RawPoll {
+    unsafe { poll_once_raw(true, pacing) }
 }
 
 /// Ask the port-1 controller to enter DualShock analog mode. Returns
@@ -280,7 +396,7 @@ fn poll_state(port2: bool) -> PadState {
     let mut last = PadState::NONE;
     let mut tries = 0;
     while tries < 4 {
-        let s = unsafe { poll_once(port2) };
+        let s = unsafe { poll_once_raw(port2, Pacing::AckWait) }.to_state();
         if !s.is_connected() {
             return s; // nothing attached -- not a glitch, don't retry
         }
@@ -307,44 +423,54 @@ unsafe fn drain_rx() {
     }
 }
 
-unsafe fn poll_once(port2: bool) -> PadState {
+unsafe fn poll_once_raw(port2: bool, pacing: Pacing) -> RawPoll {
     unsafe {
-        // Reset port state: raise JOYN then drop it, so the attached
-        // device's state machine starts from idle.
+        // Raise JOYN (and arm the DSR latch) so the device's state machine
+        // starts from idle, then drain any stale RX byte.
         select(port2);
         drain_rx();
 
-        let _select = exchange(0x01);
-        let id_lo = exchange(0x42);
-        let mode = mode_from_id_low(id_lo);
+        let mut ack = 0u16;
+        let mut i = 0u8;
+
+        // The select byte and the poll command are never the final byte of any
+        // packet, so they are always `/ACK`-paced under `AckWait`.
+        let _select = ex(port2, pacing, 0x01, false, &mut ack, &mut i);
+        let id_low = ex(port2, pacing, 0x42, false, &mut ack, &mut i);
+        let mut mode = mode_from_id_low(id_low);
         if !mode.is_connected() {
             deselect();
-            return PadState {
-                id_low: id_lo,
-                ..PadState::NONE
+            return RawPoll {
+                exchanges: i,
+                ack_seen: ack,
+                ..RawPoll::disconnected(id_low)
             };
         }
 
-        let id_hi = exchange(0x00);
-        if id_hi != 0x5A {
-            deselect();
-            return PadState {
-                mode: PadMode::Unknown,
-                id_low: id_lo,
-                ..PadState::NONE
-            };
+        let analog = mode.has_sticks();
+        let id_high = ex(port2, pacing, 0x00, false, &mut ack, &mut i);
+        if id_high != 0x5A {
+            // Garbled handshake -- treat as Unknown and stop after the two
+            // button bytes (we can no longer trust the reported length).
+            mode = PadMode::Unknown;
         }
 
-        let b0 = exchange(0x00);
-        let b1 = exchange(0x00);
-        let buttons = decode_buttons(b0, b1);
+        // For a digital pad the second button byte is the final byte (no `/ACK`
+        // follows). For an analog pad the four stick bytes come after it.
+        let read_sticks = analog && mode != PadMode::Unknown;
+        let b0 = ex(port2, pacing, 0x00, false, &mut ack, &mut i);
+        let b1 = ex(port2, pacing, 0x00, !read_sticks, &mut ack, &mut i);
 
-        let sticks = if mode.has_sticks() {
+        let sticks = if read_sticks {
+            let right_x = ex(port2, pacing, 0x00, false, &mut ack, &mut i);
+            let right_y = ex(port2, pacing, 0x00, false, &mut ack, &mut i);
+            let left_x = ex(port2, pacing, 0x00, false, &mut ack, &mut i);
+            let left_y = ex(port2, pacing, 0x00, true, &mut ack, &mut i);
             AnalogSticks {
-                right_x: exchange(0x00),
-                right_y: exchange(0x00),
-                left_x: exchange(0x00),
-                left_y: exchange(0x00),
+                right_x,
+                right_y,
+                left_x,
+                left_y,
             }
         } else {
             AnalogSticks::CENTERED
@@ -352,11 +478,44 @@ unsafe fn poll_once(port2: bool) -> PadState {
 
         deselect();
 
-        PadState {
-            buttons,
-            mode,
+        RawPoll {
+            id_low,
+            id_high,
+            buttons_low: b0,
+            buttons_high: b1,
             sticks,
-            id_low: id_lo,
+            mode,
+            ack_seen: ack,
+            exchanges: i,
+        }
+    }
+}
+
+/// Clock one byte of a transaction under the given pacing, recording whether the
+/// device acknowledged it. `is_last` marks the final byte of the packet, which
+/// the device never acknowledges, so it is always sent without an `/ACK` wait.
+#[inline]
+unsafe fn ex(
+    port2: bool,
+    pacing: Pacing,
+    tx: u8,
+    is_last: bool,
+    ack_seen: &mut u16,
+    idx: &mut u8,
+) -> u8 {
+    unsafe {
+        let i = *idx;
+        *idx = idx.wrapping_add(1);
+        match pacing {
+            Pacing::NoAckWait => exchange_nowait(tx),
+            Pacing::AckWait if is_last => exchange_nowait(tx),
+            Pacing::AckWait => {
+                let (byte, acked) = exchange_ack(port2, tx);
+                if acked && i < 16 {
+                    *ack_seen |= 1u16 << i;
+                }
+                byte
+            }
         }
     }
 }
@@ -392,30 +551,43 @@ fn decode_buttons(b0: u8, b1: u8) -> ButtonState {
     ButtonState::from_bits(!((b0 as u16) | ((b1 as u16) << 8)))
 }
 
+/// CTRL value held while a port is selected: JOYN asserted, TX/RX enabled, and
+/// the DSR (`/ACK`) interrupt armed so STAT bit 9 latches each pulse.
+#[inline]
+const fn active_ctrl(port2: bool) -> u16 {
+    let slot = if port2 { CTRL_SLOT_PORT2 } else { 0 };
+    slot | CTRL_TXEN | CTRL_RXEN | CTRL_JOYN | CTRL_ACK_IRQ_EN
+}
+
 /// Select the requested controller port and prepare SIO0 for a new
 /// transaction.
 #[inline]
 unsafe fn select(port2: bool) {
     unsafe {
-        let slot = if port2 { CTRL_SLOT_PORT2 } else { 0 };
         psx_io::write16(sio::MODE, MODE_8N1);
         psx_io::write16(sio::BAUD, BAUD_PAD);
+        // Clear any stale IRQ latch from the previous transaction, then assert
+        // JOYN with the DSR interrupt enabled.
         psx_io::write16(sio::CTRL, CTRL_ACK);
-        psx_io::write16(sio::CTRL, slot | CTRL_TXEN | CTRL_RXEN | CTRL_JOYN);
+        psx_io::write16(sio::CTRL, active_ctrl(port2));
     }
 }
 
-/// Run a fixed eight-byte DualShock command after the port-level
-/// controller select byte.
+/// Run a fixed eight-byte DualShock command after the port-level controller
+/// select byte. ACK-paced like a normal poll: every byte except the last of the
+/// nine-byte packet is `/ACK`-acknowledged by the device.
 #[inline]
 unsafe fn transaction(port2: bool, bytes: [u8; 8]) -> [u8; 8] {
     unsafe {
         select(port2);
-        let _select = exchange(0x01);
+        let mut ack = 0u16;
+        let mut idx = 0u8;
+        let _select = ex(port2, Pacing::AckWait, 0x01, false, &mut ack, &mut idx);
         let mut out = [0u8; 8];
         let mut i = 0;
         while i < bytes.len() {
-            out[i] = exchange(bytes[i]);
+            let is_last = i == bytes.len() - 1;
+            out[i] = ex(port2, Pacing::AckWait, bytes[i], is_last, &mut ack, &mut idx);
             i += 1;
         }
         deselect();
@@ -430,32 +602,88 @@ unsafe fn deselect() {
     unsafe { psx_io::write16(sio::CTRL, 0) };
 }
 
-/// Clock one byte across the serial link. Waits for TX ready, writes
-/// the byte, then waits for RX to fill before reading.
+/// Clock one byte across the serial link without waiting for `/ACK`: wait for
+/// TX-ready, write the byte, wait for RX to fill, read it. This is the legacy
+/// timing -- correct for the final byte of a packet (which is never
+/// acknowledged) and for the [`Pacing::NoAckWait`] diagnostic path.
 ///
 /// The STAT register layout (from PSX-SPX):
 /// - bit 0: TX-ready-1 (FIFO can accept a byte)
 /// - bit 1: RX FIFO not empty
-/// - bit 2: TX-ready-2 (last byte has cleared the shifter)
+/// - bit 7: `/ACK` (DSR) live input level
+/// - bit 9: latched DSR/ACK interrupt
 #[inline]
-unsafe fn exchange(tx: u8) -> u8 {
+unsafe fn exchange_nowait(tx: u8) -> u8 {
     unsafe {
-        if !wait_stat(0x1) {
+        if !wait_stat(STAT_TX_READY, EXCHANGE_WAIT_SPINS) {
             return 0xFF;
         }
         psx_io::write8(sio::DATA, tx);
-        if !wait_stat(0x2) {
+        if !wait_stat(STAT_RX_NOT_EMPTY, EXCHANGE_WAIT_SPINS) {
             return 0xFF;
         }
         psx_io::read8(sio::DATA)
     }
 }
 
+/// Clock one byte, then wait for the device's `/ACK` (DSR) pulse before
+/// returning so the caller does not clock the next byte until the controller is
+/// ready. Returns `(rx_byte, ack_observed)`.
+///
+/// The wait is non-fatal: on timeout we still return the received byte (the
+/// byte shift itself already completed), so a device that never `/ACK`s degrades
+/// to legacy timing rather than dropping the poll entirely.
 #[inline]
-unsafe fn wait_stat(mask: u32) -> bool {
-    let mut spins = EXCHANGE_WAIT_SPINS;
+unsafe fn exchange_ack(port2: bool, tx: u8) -> (u8, bool) {
+    unsafe {
+        if !wait_stat(STAT_TX_READY, EXCHANGE_WAIT_SPINS) {
+            return (0xFF, false);
+        }
+        psx_io::write8(sio::DATA, tx);
+        if !wait_stat(STAT_RX_NOT_EMPTY, EXCHANGE_WAIT_SPINS) {
+            return (0xFF, false);
+        }
+        let rx = psx_io::read8(sio::DATA);
+        // Wait for the latched `/ACK` interrupt (STAT bit 9). The latch cannot be
+        // missed, unlike the brief live level; the controller IRQ is masked in
+        // `I_MASK`, so this never reaches the CPU.
+        let acked = wait_stat(STAT_IRQ, ACK_WAIT_SPINS);
+        if acked {
+            // SIO0 STAT.9 is not edge-triggered: it can only be cleared once the
+            // live `/ACK` line has released (STAT.7 low). Wait for that, then
+            // pulse CTRL.ACK while keeping JOYN asserted so the device stays
+            // selected for the next byte.
+            let _ = wait_stat_low(STAT_DSR_LEVEL, ACK_WAIT_SPINS);
+            psx_io::write16(sio::CTRL, active_ctrl(port2) | CTRL_ACK);
+        }
+        (rx, acked)
+    }
+}
+
+/// Spin until `mask` bits are set in STAT, bounded by `spins`. Returns `false`
+/// on timeout.
+#[inline]
+unsafe fn wait_stat(mask: u32, spins: u32) -> bool {
+    let mut spins = spins;
     unsafe {
         while psx_io::read32(sio::STAT) & mask == 0 {
+            if spins == 0 {
+                return false;
+            }
+            spins -= 1;
+            core::hint::spin_loop();
+        }
+    }
+    true
+}
+
+/// Spin until `mask` bits are clear in STAT, bounded by `spins`. Returns `false`
+/// on timeout.
+#[inline]
+unsafe fn wait_stat_low(mask: u32, spins: u32) -> bool {
+    let mut spins = spins;
+    unsafe {
+        while psx_io::read32(sio::STAT) & mask != 0 {
             if spins == 0 {
                 return false;
             }
@@ -491,5 +719,54 @@ mod tests {
     fn centred_stick_helpers_return_zero() {
         assert_eq!(AnalogSticks::CENTERED.left_centered(), (0, 0));
         assert_eq!(AnalogSticks::CENTERED.right_centered(), (0, 0));
+    }
+
+    #[test]
+    fn raw_poll_to_state_inverts_buttons() {
+        let raw = RawPoll {
+            id_low: 0x41,
+            id_high: 0x5A,
+            buttons_low: 0xEF,  // UP pressed (active-low)
+            buttons_high: 0xBF, // CROSS pressed (active-low)
+            sticks: AnalogSticks::CENTERED,
+            mode: PadMode::Digital,
+            ack_seen: 0,
+            exchanges: 5,
+        };
+        let state = raw.to_state();
+        assert!(state.buttons.is_held(button::UP));
+        assert!(state.buttons.is_held(button::CROSS));
+        assert_eq!(state.mode, PadMode::Digital);
+        assert_eq!(state.id_low, 0x41);
+    }
+
+    #[test]
+    fn ack_complete_requires_every_non_final_byte_acked() {
+        // Digital poll: 5 exchanges (select, cmd, id_hi, b0, b1). The first four
+        // must ACK; the final b1 does not.
+        let mut raw = RawPoll {
+            id_low: 0x41,
+            id_high: 0x5A,
+            buttons_low: 0xFF,
+            buttons_high: 0xFF,
+            sticks: AnalogSticks::CENTERED,
+            mode: PadMode::Digital,
+            ack_seen: 0b0_1111, // exchanges 0..=3 acked
+            exchanges: 5,
+        };
+        assert!(raw.ack_complete());
+
+        // Drop one ACK in the middle -> incomplete handshake.
+        raw.ack_seen = 0b0_1011;
+        assert!(!raw.ack_complete());
+
+        // A no-ack poll (legacy / slow original under NoAckWait) is incomplete.
+        raw.ack_seen = 0;
+        assert!(!raw.ack_complete());
+    }
+
+    #[test]
+    fn pacing_round_trips() {
+        assert_ne!(Pacing::NoAckWait, Pacing::AckWait);
     }
 }

--- a/sdk/crates/psx-pad/src/lib.rs
+++ b/sdk/crates/psx-pad/src/lib.rs
@@ -337,6 +337,15 @@ const EXCHANGE_WAIT_SPINS: u32 = 32_768;
 /// ~100us DSR timeout on hardware and the emulator's ~1k-cycle ACK deadline,
 /// so a genuinely slow original controller is still given time to answer.
 const ACK_WAIT_SPINS: u32 = 2_048;
+/// Setup delay (bounded STAT reads) after asserting the select line, before the
+/// first clock. The original SCPH-1200 gives NO response without it and a clean
+/// `5A41` digital read with it; fast clones tolerate it either way (silicon,
+/// 2026-06-22). The on-console sweep put the floor between 384 (no response) and
+/// 768 (clean) under a 5-polls-per-frame stress harder than the in-game one poll
+/// per frame, so 1024 is a comfortable margin while keeping the per-poll
+/// busy-wait small. (The BIOS uses ~7us of setup but also paces every byte; our
+/// setup-only path trades a bigger setup for no inter-byte delay.)
+pub const DEFAULT_SETUP_SPINS: u32 = 1_024;
 
 /// Poll the controller in port 1 once.
 ///
@@ -365,6 +374,16 @@ pub fn poll_port1_raw(pacing: Pacing) -> RawPoll {
 /// Port-2 counterpart of [`poll_port1_raw`].
 pub fn poll_port2_raw(pacing: Pacing) -> RawPoll {
     unsafe { poll_once_raw(true, pacing) }
+}
+
+/// Poll port 1 once with explicit fixed timing, for hardware diagnostics:
+/// `setup_spins` of delay after asserting the select line, plus `interbyte_spins`
+/// of fixed delay after each byte (bounded STAT reads -- no CTRL writes, no
+/// `/ACK` wait, no DSR IRQ). This isolates the two timings a strict original pad
+/// (SCPH-1200) might need -- setup time after `/CS`, and an inter-byte gap --
+/// without the machinery that corrupted the ack-wait path on silicon.
+pub fn poll_port1_diag(setup_spins: u32, interbyte_spins: u32) -> RawPoll {
+    unsafe { poll_once_diag(false, setup_spins, interbyte_spins) }
 }
 
 /// Ask the port-1 controller to enter DualShock analog mode. Returns
@@ -396,7 +415,10 @@ fn poll_state(port2: bool) -> PadState {
     let mut last = PadState::NONE;
     let mut tries = 0;
     while tries < 4 {
-        let s = unsafe { poll_once_raw(port2, Pacing::AckWait) }.to_state();
+        // The default poll uses a setup delay after select: the original
+        // SCPH-1200 will not answer without it (silicon-confirmed), clones are
+        // fine with it. No inter-byte delay is needed.
+        let s = unsafe { poll_once_diag(port2, DEFAULT_SETUP_SPINS, 0) }.to_state();
         if !s.is_connected() {
             return s; // nothing attached -- not a glitch, don't retry
         }
@@ -425,9 +447,9 @@ unsafe fn drain_rx() {
 
 unsafe fn poll_once_raw(port2: bool, pacing: Pacing) -> RawPoll {
     unsafe {
-        // Raise JOYN (and arm the DSR latch) so the device's state machine
-        // starts from idle, then drain any stale RX byte.
-        select(port2);
+        // Raise JOYN so the device's state machine starts from idle, then drain
+        // any stale RX byte. Only the ack-wait path arms the DSR IRQ.
+        select(port2, matches!(pacing, Pacing::AckWait));
         drain_rx();
 
         let mut ack = 0u16;
@@ -520,6 +542,73 @@ unsafe fn ex(
     }
 }
 
+/// Diagnostic poll with fixed setup and inter-byte delays (no `/ACK` wait).
+/// Mirrors [`poll_once_raw`]'s byte sequence but paces purely with time.
+unsafe fn poll_once_diag(port2: bool, setup_spins: u32, interbyte_spins: u32) -> RawPoll {
+    unsafe {
+        select(port2, false);
+        // Setup time after asserting /CS, before the first clock -- the strict
+        // original pad may need this where a fast clone does not.
+        delay_reads(setup_spins);
+        drain_rx();
+
+        let mut i = 0u8;
+        let _select = exchange_delayed(0x01, interbyte_spins);
+        i += 1;
+        let id_low = exchange_delayed(0x42, interbyte_spins);
+        i += 1;
+        let mut mode = mode_from_id_low(id_low);
+        if !mode.is_connected() {
+            deselect();
+            return RawPoll {
+                exchanges: i,
+                ..RawPoll::disconnected(id_low)
+            };
+        }
+
+        let analog = mode.has_sticks();
+        let id_high = exchange_delayed(0x00, interbyte_spins);
+        i += 1;
+        if id_high != 0x5A {
+            mode = PadMode::Unknown;
+        }
+        let read_sticks = analog && mode != PadMode::Unknown;
+        let b0 = exchange_delayed(0x00, interbyte_spins);
+        i += 1;
+        let b1 = exchange_delayed(0x00, interbyte_spins);
+        i += 1;
+
+        let sticks = if read_sticks {
+            let right_x = exchange_delayed(0x00, interbyte_spins);
+            let right_y = exchange_delayed(0x00, interbyte_spins);
+            let left_x = exchange_delayed(0x00, interbyte_spins);
+            let left_y = exchange_delayed(0x00, interbyte_spins);
+            i += 4;
+            AnalogSticks {
+                right_x,
+                right_y,
+                left_x,
+                left_y,
+            }
+        } else {
+            AnalogSticks::CENTERED
+        };
+
+        deselect();
+
+        RawPoll {
+            id_low,
+            id_high,
+            buttons_low: b0,
+            buttons_high: b1,
+            sticks,
+            mode,
+            ack_seen: 0,
+            exchanges: i,
+        }
+    }
+}
+
 fn enable_analog(port2: bool) -> bool {
     unsafe {
         // Enter config mode.
@@ -552,42 +641,53 @@ fn decode_buttons(b0: u8, b1: u8) -> ButtonState {
 }
 
 /// CTRL value held while a port is selected: JOYN asserted, TX/RX enabled, and
-/// the DSR (`/ACK`) interrupt armed so STAT bit 9 latches each pulse.
+/// (only when `ack_irq`) the DSR (`/ACK`) interrupt armed so STAT bit 9 latches
+/// each pulse. The default no-wait poll leaves the DSR IRQ off -- enabling it
+/// turned out to disturb real-hardware transfers (the official SCPH-1200 stopped
+/// answering, the clone's bytes corrupted), so it is reserved for the opt-in
+/// ack-wait diagnostic only.
 #[inline]
-const fn active_ctrl(port2: bool) -> u16 {
+const fn active_ctrl(port2: bool, ack_irq: bool) -> u16 {
     let slot = if port2 { CTRL_SLOT_PORT2 } else { 0 };
-    slot | CTRL_TXEN | CTRL_RXEN | CTRL_JOYN | CTRL_ACK_IRQ_EN
+    let base = slot | CTRL_TXEN | CTRL_RXEN | CTRL_JOYN;
+    if ack_irq {
+        base | CTRL_ACK_IRQ_EN
+    } else {
+        base
+    }
 }
 
 /// Select the requested controller port and prepare SIO0 for a new
-/// transaction.
+/// transaction. `ack_irq` arms the DSR interrupt (only the ack-wait diagnostic
+/// path wants it).
 #[inline]
-unsafe fn select(port2: bool) {
+unsafe fn select(port2: bool, ack_irq: bool) {
     unsafe {
         psx_io::write16(sio::MODE, MODE_8N1);
         psx_io::write16(sio::BAUD, BAUD_PAD);
         // Clear any stale IRQ latch from the previous transaction, then assert
-        // JOYN with the DSR interrupt enabled.
+        // JOYN.
         psx_io::write16(sio::CTRL, CTRL_ACK);
-        psx_io::write16(sio::CTRL, active_ctrl(port2));
+        psx_io::write16(sio::CTRL, active_ctrl(port2, ack_irq));
     }
 }
 
 /// Run a fixed eight-byte DualShock command after the port-level controller
-/// select byte. ACK-paced like a normal poll: every byte except the last of the
-/// nine-byte packet is `/ACK`-acknowledged by the device.
+/// select byte, using the default no-wait timing (matching the reverted poll
+/// path).
 #[inline]
 unsafe fn transaction(port2: bool, bytes: [u8; 8]) -> [u8; 8] {
     unsafe {
-        select(port2);
+        select(port2, false);
+        delay_reads(DEFAULT_SETUP_SPINS);
         let mut ack = 0u16;
         let mut idx = 0u8;
-        let _select = ex(port2, Pacing::AckWait, 0x01, false, &mut ack, &mut idx);
+        let _select = ex(port2, Pacing::NoAckWait, 0x01, false, &mut ack, &mut idx);
         let mut out = [0u8; 8];
         let mut i = 0;
         while i < bytes.len() {
             let is_last = i == bytes.len() - 1;
-            out[i] = ex(port2, Pacing::AckWait, bytes[i], is_last, &mut ack, &mut idx);
+            out[i] = ex(port2, Pacing::NoAckWait, bytes[i], is_last, &mut ack, &mut idx);
             i += 1;
         }
         deselect();
@@ -626,6 +726,30 @@ unsafe fn exchange_nowait(tx: u8) -> u8 {
     }
 }
 
+/// One no-wait byte exchange followed by a fixed inter-byte delay, giving a
+/// strict pad time to be ready for the next byte without any `/ACK`/CTRL games.
+#[inline]
+unsafe fn exchange_delayed(tx: u8, interbyte_spins: u32) -> u8 {
+    unsafe {
+        let rx = exchange_nowait(tx);
+        delay_reads(interbyte_spins);
+        rx
+    }
+}
+
+/// Burn time by reading STAT `n` times -- a real, non-optimizable MMIO delay.
+#[inline]
+unsafe fn delay_reads(n: u32) {
+    let mut k = n;
+    unsafe {
+        while k > 0 {
+            let _ = psx_io::read32(sio::STAT);
+            k -= 1;
+            core::hint::spin_loop();
+        }
+    }
+}
+
 /// Clock one byte, then wait for the device's `/ACK` (DSR) pulse before
 /// returning so the caller does not clock the next byte until the controller is
 /// ready. Returns `(rx_byte, ack_observed)`.
@@ -654,7 +778,7 @@ unsafe fn exchange_ack(port2: bool, tx: u8) -> (u8, bool) {
             // pulse CTRL.ACK while keeping JOYN asserted so the device stays
             // selected for the next byte.
             let _ = wait_stat_low(STAT_DSR_LEVEL, ACK_WAIT_SPINS);
-            psx_io::write16(sio::CTRL, active_ctrl(port2) | CTRL_ACK);
+            psx_io::write16(sio::CTRL, active_ctrl(port2, true) | CTRL_ACK);
         }
         (rx, acked)
     }


### PR DESCRIPTION
## What

The SDK's hand-rolled SIO0 pad poll worked with a cheap third-party
controller, but the original Sony SCPH-1200 (DualShock) gave no response
at all on real hardware. The cause, confirmed on a modchipped console, is
a missing setup delay after asserting the select line (DTR/JOYN) before
the first clock: the original pad's ASIC needs that settle time, fast
clones do not. `poll_state` and the config transactions now wait
`DEFAULT_SETUP_SPINS` after select.

Cross-checked against OpenBIOS (`src/mips/openbios/sio0`): the BIOS does
exactly this (`busyloop(40)` after raising DTR), and its JOY_BAUD (0x88)
and JOY_MODE (0x0D) match ours, so the register setup was never the issue.

## How we got here

The first attempt (commit 02a8e4ab) theorized that original pads needed
`/ACK` (DSR) pacing between bytes. Hardware disproved it: that approach
corrupted the clone, and the official pad's real problem was setup timing,
not inter-byte ACK. Commit 1b84b010 reverts the ACK-wait default and ships
the setup-delay fix. An on-console setup-delay sweep put the floor between
384 and 768 spins, shipped at 1024 with margin.

## Also in here

- `hardware-tests`: the boot screen is now an on-console controller probe
  and setup-delay sweep, plus stricter SIO section tests.
- emulator: an opt-in slow/ACK-gated pad model (`--slow-pad`) used while
  diagnosing. Note it models a hypothetical slow-ACK device and does not
  reproduce the real SCPH-1200 (whose issue was setup timing).

## Testing

- `psx-pad` host unit tests, the `hello-input` SDK golden, and all
  `emulator-core` tests pass.
- Verified on a real modchipped PS1: both the SCPH-1200 and the clone read
  cleanly and navigate menus. A pressed FF7 disc (real BIOS) confirmed the
  pads and console were never at fault.
