### PR TITLE
feat(frontend): reliable multi-key keyboard input, SOCD, and a live-rebind controls panel

### DIFF
--- a/emu/crates/frontend/src/app.rs
+++ b/emu/crates/frontend/src/app.rs
@@ -533,6 +533,13 @@ impl AppState {
         out.menu.sync_editor_label(out.workspace.is_editor());
         out.sync_menu_settings_paths();
         out.sync_menu_controls();
+        // Dev/preview hook in the PSOXIDE_AUTORUN tradition: open the
+        // controls panel straight away, so visual tweaks to the pad
+        // drawing can be screenshotted without clicking through the UI.
+        #[cfg(not(target_arch = "wasm32"))]
+        if env_flag("PSOXIDE_OPEN_CONTROLS") {
+            out.menu.open_controls();
+        }
         // Web: look (async) for a previously-saved BIOS/folder so the menu can
         // offer a one-click reconnect.
         #[cfg(target_arch = "wasm32")]

--- a/emu/crates/frontend/src/app.rs
+++ b/emu/crates/frontend/src/app.rs
@@ -35,7 +35,7 @@ use crate::playtest_input::{PlaytestInputEvent, PlaytestInputTape, Port1PadSampl
 use crate::ui;
 use crate::ui::hud::HudState;
 use crate::ui::memory::MemoryView;
-use crate::ui::menu::{LibraryItem as MenuLibraryItem, MenuState, SaveStateRow};
+use crate::ui::menu::{LibraryItem as MenuLibraryItem, MenuState, PadBindTarget, SaveStateRow};
 use crate::{paths_equivalent, repo_root_dir};
 
 /// Ring-buffer capacity for the execution-history panel. 16 rows is
@@ -532,6 +532,7 @@ impl AppState {
         #[cfg(feature = "editor")]
         out.menu.sync_editor_label(out.workspace.is_editor());
         out.sync_menu_settings_paths();
+        out.sync_menu_controls();
         // Web: look (async) for a previously-saved BIOS/folder so the menu can
         // offer a one-click reconnect.
         #[cfg(target_arch = "wasm32")]
@@ -1857,6 +1858,53 @@ impl AppState {
             .sync_settings_paths(self.bios_path_label(), self.games_path_label());
     }
 
+    /// Current display label for every rebindable port-1 target, for
+    /// the controls panel.
+    fn controls_labels(&self) -> Vec<(PadBindTarget, String)> {
+        PadBindTarget::ALL
+            .into_iter()
+            .map(|t| (t, binding_for_target(&self.settings.input.port1, t).label()))
+            .collect()
+    }
+
+    /// Push the current binding labels into the Menu's controls panel.
+    pub fn sync_menu_controls(&mut self) {
+        let labels = self.controls_labels();
+        self.menu.sync_controls(labels);
+    }
+
+    /// Bind `target` to `binding`, stealing it from any other target
+    /// that currently uses the same key -- one physical key silently
+    /// driving two pad inputs is never what the user meant. Persists
+    /// immediately and refreshes the panel labels; key events read the
+    /// bindings live, so the change applies to the running game on the
+    /// very next press.
+    pub fn apply_rebind(&mut self, target: PadBindTarget, binding: psoxide_settings::InputBinding) {
+        for other in PadBindTarget::ALL {
+            if other != target && *binding_for_target(&self.settings.input.port1, other) == binding
+            {
+                *binding_for_target_mut(&mut self.settings.input.port1, other) =
+                    psoxide_settings::InputBinding::Unbound;
+            }
+        }
+        *binding_for_target_mut(&mut self.settings.input.port1, target) = binding.clone();
+        if let Err(e) = self.save_settings() {
+            eprintln!("[frontend] settings save after rebind: {e}");
+        }
+        self.sync_menu_controls();
+        self.status_message_set(format!("{} bound to {}", target.label(), binding.label()));
+    }
+
+    /// Restore every port-1 binding to the built-in defaults.
+    pub fn reset_controls(&mut self) {
+        self.settings.input.port1 = psoxide_settings::settings::PortBindings::default();
+        if let Err(e) = self.save_settings() {
+            eprintln!("[frontend] settings save after controls reset: {e}");
+        }
+        self.sync_menu_controls();
+        self.status_message_set("Controls reset to defaults".to_string());
+    }
+
     #[cfg(not(target_arch = "wasm32"))]
     fn bios_path_label(&self) -> String {
         let configured = self.settings.paths.bios.trim();
@@ -3019,6 +3067,76 @@ fn maybe_fast_boot_disc(
     enabled: bool,
 ) -> &'static str {
     maybe_fast_boot_disc_path(bus, cpu, disc, &entry.path, enabled)
+}
+
+/// The settings field a rebind target reads from. Kept as a pair of
+/// free functions (rather than one `&mut` accessor used for reads too)
+/// so label-building can borrow the settings immutably.
+fn binding_for_target(
+    b: &psoxide_settings::settings::PortBindings,
+    target: PadBindTarget,
+) -> &psoxide_settings::InputBinding {
+    match target {
+        PadBindTarget::Up => &b.up,
+        PadBindTarget::Down => &b.down,
+        PadBindTarget::Left => &b.left,
+        PadBindTarget::Right => &b.right,
+        PadBindTarget::Cross => &b.cross,
+        PadBindTarget::Circle => &b.circle,
+        PadBindTarget::Square => &b.square,
+        PadBindTarget::Triangle => &b.triangle,
+        PadBindTarget::L1 => &b.l1,
+        PadBindTarget::L2 => &b.l2,
+        PadBindTarget::R1 => &b.r1,
+        PadBindTarget::R2 => &b.r2,
+        PadBindTarget::Start => &b.start,
+        PadBindTarget::Select => &b.select,
+        PadBindTarget::L3 => &b.l3,
+        PadBindTarget::R3 => &b.r3,
+        PadBindTarget::Analog => &b.analog,
+        PadBindTarget::LStickUp => &b.left_stick.up,
+        PadBindTarget::LStickDown => &b.left_stick.down,
+        PadBindTarget::LStickLeft => &b.left_stick.left,
+        PadBindTarget::LStickRight => &b.left_stick.right,
+        PadBindTarget::RStickUp => &b.right_stick.up,
+        PadBindTarget::RStickDown => &b.right_stick.down,
+        PadBindTarget::RStickLeft => &b.right_stick.left,
+        PadBindTarget::RStickRight => &b.right_stick.right,
+    }
+}
+
+/// Mutable twin of [`binding_for_target`], for rebind writes.
+fn binding_for_target_mut(
+    b: &mut psoxide_settings::settings::PortBindings,
+    target: PadBindTarget,
+) -> &mut psoxide_settings::InputBinding {
+    match target {
+        PadBindTarget::Up => &mut b.up,
+        PadBindTarget::Down => &mut b.down,
+        PadBindTarget::Left => &mut b.left,
+        PadBindTarget::Right => &mut b.right,
+        PadBindTarget::Cross => &mut b.cross,
+        PadBindTarget::Circle => &mut b.circle,
+        PadBindTarget::Square => &mut b.square,
+        PadBindTarget::Triangle => &mut b.triangle,
+        PadBindTarget::L1 => &mut b.l1,
+        PadBindTarget::L2 => &mut b.l2,
+        PadBindTarget::R1 => &mut b.r1,
+        PadBindTarget::R2 => &mut b.r2,
+        PadBindTarget::Start => &mut b.start,
+        PadBindTarget::Select => &mut b.select,
+        PadBindTarget::L3 => &mut b.l3,
+        PadBindTarget::R3 => &mut b.r3,
+        PadBindTarget::Analog => &mut b.analog,
+        PadBindTarget::LStickUp => &mut b.left_stick.up,
+        PadBindTarget::LStickDown => &mut b.left_stick.down,
+        PadBindTarget::LStickLeft => &mut b.left_stick.left,
+        PadBindTarget::LStickRight => &mut b.left_stick.right,
+        PadBindTarget::RStickUp => &mut b.right_stick.up,
+        PadBindTarget::RStickDown => &mut b.right_stick.down,
+        PadBindTarget::RStickLeft => &mut b.right_stick.left,
+        PadBindTarget::RStickRight => &mut b.right_stick.right,
+    }
 }
 
 fn maybe_fast_boot_disc_path(

--- a/emu/crates/frontend/src/input.rs
+++ b/emu/crates/frontend/src/input.rs
@@ -130,6 +130,13 @@ pub struct InputFrame {
     /// phantom combo when the user is actually opening the menu.
     pub pad1_mask: u16,
 
+    /// Buttons that transitioned from up to down during this poll
+    /// (rising edges of the merged mask). The shell folds the
+    /// directional bits into SOCD recency so a fresh gamepad press
+    /// competes fairly with held keyboard directions; consumers
+    /// filter for the bits they care about.
+    pub pressed_mask: u16,
+
     /// Rising-edge of Select+Start on any pad -- goes `true` for
     /// exactly one frame after both become held. The shell wires
     /// this into `MenuInput.toggle_open`, reusing the same path
@@ -162,6 +169,14 @@ pub struct InputFrame {
     pub left_stick: (f32, f32),
     /// Right stick on the first currently-connected pad.
     pub right_stick: (f32, f32),
+}
+
+/// Buttons that transitioned from up to down between two polls.
+/// Shared by the native and web routers so `InputFrame::pressed_mask`
+/// carries identical semantics on both -- the SOCD recency fed from it
+/// must not behave differently per platform.
+fn rising_edges(prev: u16, now: u16) -> u16 {
+    now & !prev
 }
 
 /// One tracked pad. Name is captured at connect time so we can
@@ -329,7 +344,7 @@ impl InputRouter {
         //    the chord, so `menu_confirm` / `menu_back` pick up on
         //    Cross / Circle normally, but the chord logic sees
         //    the raw combination too.
-        let edge = mask & !self.prev_mask;
+        let edge = rising_edges(self.prev_mask, mask);
         let chord_active = (mask & CHORD_MASK) == CHORD_MASK;
         let chord_was_active = (self.prev_mask & CHORD_MASK) == CHORD_MASK;
         let toggle_menu = chord_active && !chord_was_active;
@@ -350,6 +365,7 @@ impl InputRouter {
             } else {
                 mask
             },
+            pressed_mask: edge,
             toggle_menu,
             analog_button,
             menu_up: (edge & button::UP) != 0,
@@ -635,7 +651,10 @@ impl InputRouter {
         frame.analog_button = analog && !self.prev_analog;
         self.prev_analog = analog;
 
-        // Menu-nav rising edges off the D-pad and face buttons.
+        // Menu-nav rising edges off the D-pad and face buttons, plus
+        // the raw edge mask the shell folds into SOCD recency --
+        // the same `rising_edges` the native router uses.
+        frame.pressed_mask = rising_edges(self.prev_mask, mask);
         let edge = |bit: u16| (mask & bit != 0) && (self.prev_mask & bit == 0);
         frame.menu_up = edge(button::UP);
         frame.menu_down = edge(button::DOWN);
@@ -679,4 +698,29 @@ fn first_connected_gamepad() -> Option<web_sys::Gamepad> {
         }
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::rising_edges;
+
+    #[test]
+    fn rising_edges_reports_only_new_presses() {
+        use emulator_core::button;
+        // Nothing held before: every held bit is an edge.
+        assert_eq!(
+            rising_edges(0, button::LEFT | button::CROSS),
+            button::LEFT | button::CROSS
+        );
+        // Still-held bits stop being edges; releases contribute nothing.
+        assert_eq!(rising_edges(button::LEFT, button::LEFT), 0);
+        assert_eq!(rising_edges(button::LEFT, 0), 0);
+        // A new press alongside a held one reports only the new press --
+        // the property SOCD recency depends on: the frame gamepad RIGHT
+        // lands while LEFT is held must expose exactly RIGHT.
+        assert_eq!(
+            rising_edges(button::LEFT, button::LEFT | button::RIGHT),
+            button::RIGHT
+        );
+    }
 }

--- a/emu/crates/frontend/src/main.rs
+++ b/emu/crates/frontend/src/main.rs
@@ -195,6 +195,19 @@ struct Shell {
     /// frame before running CPU steps so the guest always sees the
     /// latest state.
     pad1_mask: u16,
+    /// Most recently *pressed* button of the LEFT/RIGHT pair, for SOCD
+    /// (simultaneous opposing cardinal directions) resolution. The real
+    /// PS1 d-pad is a physical rocker -- left+right can never be down
+    /// together, so games were never written for both bits set and react
+    /// unpredictably (most just keep the old direction). A keyboard makes
+    /// the combination trivial to produce, so when both are held the mask
+    /// sent to the guest keeps only the most recent press; releasing it
+    /// re-exposes the still-held opposite. Last-input-priority matches
+    /// what a player expects from tapping the other direction without
+    /// letting go first.
+    socd_last_horiz: u16,
+    /// Same, for the UP/DOWN pair.
+    socd_last_vert: u16,
     /// Previous-frame state of the L3+R3 freelook chord, for rising-edge
     /// toggle detection.
     prev_freelook_chord: bool,
@@ -314,6 +327,8 @@ impl Shell {
             pending_input: MenuInput::default(),
             last_frame: Instant::now(),
             pad1_mask: 0,
+            socd_last_horiz: 0,
+            socd_last_vert: 0,
             prev_freelook_chord: false,
             keyboard_left_stick: KeyboardStickState::default(),
             keyboard_right_stick: KeyboardStickState::default(),
@@ -451,6 +466,25 @@ fn merge_axis(gamepad: f32, keyboard: f32) -> f32 {
     } else {
         gamepad
     }
+}
+
+/// Strip simultaneous opposing cardinal directions from the pad mask,
+/// keeping only the most recently pressed side of each pair (see
+/// `Shell::socd_last_horiz`). The real d-pad's rocker makes the
+/// combination impossible, so the guest must never see it; with no
+/// recorded recency (or a stale one no longer held) the pair resolves
+/// to neutral, which is what the rocker does mid-travel.
+fn socd_resolve(mask: u16, last_horiz: u16, last_vert: u16) -> u16 {
+    let mut out = mask;
+    const HORIZ: u16 = button::LEFT | button::RIGHT;
+    const VERT: u16 = button::UP | button::DOWN;
+    if out & HORIZ == HORIZ {
+        out = (out & !HORIZ) | (last_horiz & HORIZ);
+    }
+    if out & VERT == VERT {
+        out = (out & !VERT) | (last_vert & VERT);
+    }
+    out
 }
 
 /// Match a persisted binding against the *physical* key that changed,
@@ -700,7 +734,15 @@ impl ApplicationHandler for Shell {
                     let bindings = &self.state.settings.input.port1;
                     if let Some(mask) = key_to_pad_button(&physical_key, bindings) {
                         match state {
-                            ElementState::Pressed => self.pad1_mask |= mask,
+                            ElementState::Pressed => {
+                                self.pad1_mask |= mask;
+                                if mask & (button::LEFT | button::RIGHT) != 0 {
+                                    self.socd_last_horiz = mask;
+                                }
+                                if mask & (button::UP | button::DOWN) != 0 {
+                                    self.socd_last_vert = mask;
+                                }
+                            }
                             ElementState::Released => self.pad1_mask &= !mask,
                         }
                     }
@@ -826,7 +868,11 @@ impl ApplicationHandler for Shell {
                     merge_sticks(pad_frame.left_stick, self.keyboard_left_stick.vector());
                 let merged_right =
                     merge_sticks(pad_frame.right_stick, self.keyboard_right_stick.vector());
-                let merged_mask = self.pad1_mask | pad_frame.pad1_mask;
+                let merged_mask = socd_resolve(
+                    self.pad1_mask | pad_frame.pad1_mask,
+                    self.socd_last_horiz,
+                    self.socd_last_vert,
+                );
 
                 // Gamepad input arrives by polling, not as window events,
                 // so it cannot wake the redraw scheduler the way keyboard
@@ -2112,6 +2158,30 @@ mod tests {
             ElementState::Pressed,
             &bindings.right_stick,
         ));
+    }
+
+    #[test]
+    fn socd_resolution_keeps_most_recent_direction() {
+        // Holding LEFT, then pressing RIGHT without letting go: the guest
+        // sees only RIGHT (the recent press wins)...
+        assert_eq!(
+            socd_resolve(button::LEFT | button::RIGHT, button::RIGHT, 0),
+            button::RIGHT
+        );
+        // ...and releasing RIGHT re-exposes the still-held LEFT (the
+        // resolver never fires on a single held direction).
+        assert_eq!(socd_resolve(button::LEFT, button::RIGHT, 0), button::LEFT);
+        // No recorded recency resolves the clash to neutral.
+        assert_eq!(socd_resolve(button::UP | button::DOWN, 0, 0), 0);
+        // Pairs resolve independently; other buttons pass through.
+        assert_eq!(
+            socd_resolve(
+                button::UP | button::DOWN | button::LEFT | button::RIGHT | button::CROSS,
+                button::LEFT,
+                button::DOWN,
+            ),
+            button::LEFT | button::DOWN | button::CROSS
+        );
     }
 
     #[test]

--- a/emu/crates/frontend/src/main.rs
+++ b/emu/crates/frontend/src/main.rs
@@ -55,7 +55,7 @@ use clap::Parser;
 use winit::application::ApplicationHandler;
 use winit::event::{ElementState, KeyEvent, WindowEvent};
 use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
-use winit::keyboard::{Key, NamedKey};
+use winit::keyboard::{Key, KeyCode, NamedKey, PhysicalKey};
 use winit::window::{Window, WindowId};
 
 use crate::app::AppState;
@@ -356,10 +356,10 @@ fn press_port1_analog_button(state: &mut AppState) {
     }
 }
 
-/// Map a winit logical key to a PSX digital-pad bitmask using the
+/// Map a winit physical key to a PSX digital-pad bitmask using the
 /// persisted port-1 bindings. Returns `None` for keys that aren't
 /// bound.
-fn key_to_pad_button(key: &Key, bindings: &PortBindings) -> Option<u16> {
+fn key_to_pad_button(physical: &PhysicalKey, bindings: &PortBindings) -> Option<u16> {
     [
         (button::UP, &bindings.up),
         (button::DOWN, &bindings.down),
@@ -378,17 +378,14 @@ fn key_to_pad_button(key: &Key, bindings: &PortBindings) -> Option<u16> {
         (button::R3, &bindings.r3),
     ]
     .into_iter()
-    .find_map(|(mask, binding)| binding_matches_key(binding, key).then_some(mask))
+    .find_map(|(mask, binding)| binding_matches_key(binding, physical).then_some(mask))
 }
 
 /// `true` when the key should act as the DualShock Analog button.
-fn key_is_analog_button(key: &Key, bindings: &PortBindings) -> bool {
-    binding_matches_key(&bindings.analog, key)
+fn key_is_analog_button(physical: &PhysicalKey, bindings: &PortBindings) -> bool {
+    binding_matches_key(&bindings.analog, physical)
 }
 
-/// Update held freelook-camera key state from a keyboard event. These keys are
-/// intentionally outside the PSX pad bindings (T/F/G/H move, I/J/K/L look, U/O
-/// up-down, Shift boost), so tracking them never double-drives the guest pad.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 struct KeyboardStickState {
     up: bool,
@@ -398,22 +395,27 @@ struct KeyboardStickState {
 }
 
 impl KeyboardStickState {
-    fn update_key(&mut self, key: &Key, state: ElementState, bindings: &StickBindings) -> bool {
+    fn update_key(
+        &mut self,
+        physical: &PhysicalKey,
+        state: ElementState,
+        bindings: &StickBindings,
+    ) -> bool {
         let pressed = state == ElementState::Pressed;
         let mut matched = false;
-        if binding_matches_key(&bindings.up, key) {
+        if binding_matches_key(&bindings.up, physical) {
             self.up = pressed;
             matched = true;
         }
-        if binding_matches_key(&bindings.down, key) {
+        if binding_matches_key(&bindings.down, physical) {
             self.down = pressed;
             matched = true;
         }
-        if binding_matches_key(&bindings.left, key) {
+        if binding_matches_key(&bindings.left, physical) {
             self.left = pressed;
             matched = true;
         }
-        if binding_matches_key(&bindings.right, key) {
+        if binding_matches_key(&bindings.right, physical) {
             self.right = pressed;
             matched = true;
         }
@@ -451,34 +453,97 @@ fn merge_axis(gamepad: f32, keyboard: f32) -> f32 {
     }
 }
 
-fn binding_matches_key(binding: &InputBinding, key: &Key) -> bool {
-    match (binding, key) {
-        (InputBinding::Unbound, _) => false,
-        (InputBinding::Character(expected), Key::Character(actual)) => actual
-            .chars()
-            .next()
-            .is_some_and(|c| c.eq_ignore_ascii_case(expected)),
-        (InputBinding::Named(expected), Key::Named(actual)) => {
-            named_key_label(actual).is_some_and(|name| expected.eq_ignore_ascii_case(name))
-        }
-        _ => false,
+/// Match a persisted binding against the *physical* key that changed,
+/// rather than the logical `Key` winit derives from the current keyboard
+/// layout.
+///
+/// This used to match on `Key` (the layout-translated character/name).
+/// Windows re-runs its dead-key/AltGr translation on every keystroke, and
+/// on layouts that put a dead key near the default control cluster (ABNT2,
+/// International-US, ...) a still-held key can flip from `Key::Character`
+/// to `Key::Dead`/`Unidentified` the instant a *second* key goes down --
+/// which read as "holding a second button drops the first bind", exactly
+/// the multi-key symptom this was chasing. A physical key's `KeyCode`
+/// comes straight from the hardware scancode (or the DOM `code` on web),
+/// so it never depends on modifier state, layout, or what other keys are
+/// currently held.
+fn binding_matches_key(binding: &InputBinding, physical: &PhysicalKey) -> bool {
+    let PhysicalKey::Code(code) = physical else {
+        return false;
+    };
+    match binding {
+        InputBinding::Unbound => false,
+        InputBinding::Character(expected) => char_to_keycode(*expected) == Some(*code),
+        InputBinding::Named(expected) => named_key_codes(expected).contains(code),
     }
 }
 
-fn named_key_label(key: &NamedKey) -> Option<&'static str> {
-    match key {
-        NamedKey::ArrowUp => Some("ArrowUp"),
-        NamedKey::ArrowDown => Some("ArrowDown"),
-        NamedKey::ArrowLeft => Some("ArrowLeft"),
-        NamedKey::ArrowRight => Some("ArrowRight"),
-        NamedKey::Enter => Some("Enter"),
-        NamedKey::Backspace => Some("Backspace"),
-        NamedKey::Shift => Some("Shift"),
-        NamedKey::Space => Some("Space"),
-        NamedKey::Tab => Some("Tab"),
-        NamedKey::Escape => Some("Escape"),
-        NamedKey::F9 => Some("F9"),
-        _ => None,
+/// Physical-position mapping for a persisted `InputBinding::Character`.
+/// Bindings are stored as the character a US-QWERTY layout produces at a
+/// given position (the default set: q/e/z/x/c/s/r/1/3/i/j/k/l), so this is
+/// a fixed position table rather than a live layout query -- which is what
+/// keeps a binding stable regardless of the keyboard layout actually
+/// active at runtime.
+fn char_to_keycode(c: char) -> Option<KeyCode> {
+    Some(match c.to_ascii_lowercase() {
+        'a' => KeyCode::KeyA,
+        'b' => KeyCode::KeyB,
+        'c' => KeyCode::KeyC,
+        'd' => KeyCode::KeyD,
+        'e' => KeyCode::KeyE,
+        'f' => KeyCode::KeyF,
+        'g' => KeyCode::KeyG,
+        'h' => KeyCode::KeyH,
+        'i' => KeyCode::KeyI,
+        'j' => KeyCode::KeyJ,
+        'k' => KeyCode::KeyK,
+        'l' => KeyCode::KeyL,
+        'm' => KeyCode::KeyM,
+        'n' => KeyCode::KeyN,
+        'o' => KeyCode::KeyO,
+        'p' => KeyCode::KeyP,
+        'q' => KeyCode::KeyQ,
+        'r' => KeyCode::KeyR,
+        's' => KeyCode::KeyS,
+        't' => KeyCode::KeyT,
+        'u' => KeyCode::KeyU,
+        'v' => KeyCode::KeyV,
+        'w' => KeyCode::KeyW,
+        'x' => KeyCode::KeyX,
+        'y' => KeyCode::KeyY,
+        'z' => KeyCode::KeyZ,
+        '0' => KeyCode::Digit0,
+        '1' => KeyCode::Digit1,
+        '2' => KeyCode::Digit2,
+        '3' => KeyCode::Digit3,
+        '4' => KeyCode::Digit4,
+        '5' => KeyCode::Digit5,
+        '6' => KeyCode::Digit6,
+        '7' => KeyCode::Digit7,
+        '8' => KeyCode::Digit8,
+        '9' => KeyCode::Digit9,
+        _ => return None,
+    })
+}
+
+/// Physical keycode(s) a persisted `InputBinding::Named` label matches.
+/// Mirrors the label set the old logical-key lookup accepted; "Shift"
+/// matches either physical shift key since the binding format predates
+/// left/right being distinguished.
+fn named_key_codes(name: &str) -> &'static [KeyCode] {
+    match name.to_ascii_lowercase().as_str() {
+        "arrowup" => &[KeyCode::ArrowUp],
+        "arrowdown" => &[KeyCode::ArrowDown],
+        "arrowleft" => &[KeyCode::ArrowLeft],
+        "arrowright" => &[KeyCode::ArrowRight],
+        "enter" => &[KeyCode::Enter],
+        "backspace" => &[KeyCode::Backspace],
+        "shift" => &[KeyCode::ShiftLeft, KeyCode::ShiftRight],
+        "space" => &[KeyCode::Space],
+        "tab" => &[KeyCode::Tab],
+        "escape" => &[KeyCode::Escape],
+        "f9" => &[KeyCode::F9],
+        _ => &[],
     }
 }
 
@@ -589,10 +654,31 @@ impl ApplicationHandler for Shell {
                 gfx.resize(size);
                 gfx.window.request_redraw();
             }
+            // Losing OS focus (Alt-Tab, a notification stealing focus, an
+            // overlay like Discord/Game Bar, clicking a second monitor...)
+            // does not reliably deliver a `Released` for whatever's
+            // physically still held down -- on Windows in particular, the
+            // key-up can fire after focus already moved elsewhere, or not
+            // reach this window at all. Left unhandled, that bit (or
+            // analog-stick / freelook direction) gets stuck "held" until
+            // the same key happens to be pressed and released again,
+            // which reads as "I have to let go of one key to use another"
+            // once a second, genuinely-held key ORs into an already-stuck
+            // mask. Clear every host-key-derived input state on focus
+            // loss so a stuck bit can never survive past it; the pad
+            // simply reports "nothing held" until the player presses
+            // fresh keys after refocusing.
+            WindowEvent::Focused(false) => {
+                self.pad1_mask = 0;
+                self.keyboard_left_stick = KeyboardStickState::default();
+                self.keyboard_right_stick = KeyboardStickState::default();
+            }
+            WindowEvent::Focused(true) => {}
             WindowEvent::KeyboardInput {
                 event:
                     KeyEvent {
                         logical_key,
+                        physical_key,
                         state,
                         repeat,
                         ..
@@ -612,21 +698,21 @@ impl ApplicationHandler for Shell {
                 let route_keyboard_to_game = true;
                 if !repeat && route_keyboard_to_game {
                     let bindings = &self.state.settings.input.port1;
-                    if let Some(mask) = key_to_pad_button(&logical_key, bindings) {
+                    if let Some(mask) = key_to_pad_button(&physical_key, bindings) {
                         match state {
                             ElementState::Pressed => self.pad1_mask |= mask,
                             ElementState::Released => self.pad1_mask &= !mask,
                         }
                     }
                     self.keyboard_left_stick
-                        .update_key(&logical_key, state, &bindings.left_stick);
+                        .update_key(&physical_key, state, &bindings.left_stick);
                     self.keyboard_right_stick.update_key(
-                        &logical_key,
+                        &physical_key,
                         state,
                         &bindings.right_stick,
                     );
                     let press_analog = state == ElementState::Pressed
-                        && key_is_analog_button(&logical_key, bindings);
+                        && key_is_analog_button(&physical_key, bindings);
                     if press_analog {
                         press_port1_analog_button(&mut self.state);
                     }
@@ -1959,26 +2045,29 @@ mod tests {
         let bindings = PortBindings::default();
 
         assert_eq!(
-            key_to_pad_button(&Key::Character("x".into()), &bindings),
+            key_to_pad_button(&PhysicalKey::Code(KeyCode::KeyX), &bindings),
             Some(button::CROSS)
         );
         assert_eq!(
-            key_to_pad_button(&Key::Character("c".into()), &bindings),
+            key_to_pad_button(&PhysicalKey::Code(KeyCode::KeyC), &bindings),
             Some(button::CIRCLE)
         );
         assert_eq!(
-            key_to_pad_button(&Key::Character("z".into()), &bindings),
+            key_to_pad_button(&PhysicalKey::Code(KeyCode::KeyZ), &bindings),
             Some(button::SQUARE)
         );
         assert_eq!(
-            key_to_pad_button(&Key::Named(NamedKey::Backspace), &bindings),
+            key_to_pad_button(&PhysicalKey::Code(KeyCode::Backspace), &bindings),
             Some(button::SELECT)
         );
         assert_eq!(
-            key_to_pad_button(&Key::Character("r".into()), &bindings),
+            key_to_pad_button(&PhysicalKey::Code(KeyCode::KeyR), &bindings),
             Some(button::R3)
         );
-        assert!(key_is_analog_button(&Key::Named(NamedKey::F9), &bindings));
+        assert!(key_is_analog_button(
+            &PhysicalKey::Code(KeyCode::F9),
+            &bindings
+        ));
     }
 
     #[test]
@@ -1988,38 +2077,38 @@ mod tests {
         let mut right = KeyboardStickState::default();
 
         assert!(left.update_key(
-            &Key::Named(NamedKey::ArrowUp),
+            &PhysicalKey::Code(KeyCode::ArrowUp),
             ElementState::Pressed,
             &bindings.left_stick,
         ));
         assert_eq!(left.vector(), (0.0, 1.0));
         assert!(left.update_key(
-            &Key::Named(NamedKey::ArrowDown),
+            &PhysicalKey::Code(KeyCode::ArrowDown),
             ElementState::Pressed,
             &bindings.left_stick,
         ));
         assert_eq!(left.vector(), (0.0, 0.0));
         assert!(left.update_key(
-            &Key::Named(NamedKey::ArrowUp),
+            &PhysicalKey::Code(KeyCode::ArrowUp),
             ElementState::Released,
             &bindings.left_stick,
         ));
         assert_eq!(left.vector(), (0.0, -1.0));
 
         assert!(right.update_key(
-            &Key::Character("j".into()),
+            &PhysicalKey::Code(KeyCode::KeyJ),
             ElementState::Pressed,
             &bindings.right_stick,
         ));
         assert_eq!(right.vector(), (-1.0, 0.0));
         assert!(right.update_key(
-            &Key::Character("l".into()),
+            &PhysicalKey::Code(KeyCode::KeyL),
             ElementState::Pressed,
             &bindings.right_stick,
         ));
         assert_eq!(right.vector(), (0.0, 0.0));
         assert!(!right.update_key(
-            &Key::Character("x".into()),
+            &PhysicalKey::Code(KeyCode::KeyX),
             ElementState::Pressed,
             &bindings.right_stick,
         ));
@@ -2033,11 +2122,11 @@ mod tests {
         };
 
         assert_eq!(
-            key_to_pad_button(&Key::Character("j".into()), &bindings),
+            key_to_pad_button(&PhysicalKey::Code(KeyCode::KeyJ), &bindings),
             Some(button::CROSS)
         );
         assert_eq!(
-            key_to_pad_button(&Key::Character("x".into()), &bindings),
+            key_to_pad_button(&PhysicalKey::Code(KeyCode::KeyX), &bindings),
             None
         );
     }
@@ -2054,13 +2143,13 @@ mod tests {
         let mut right = KeyboardStickState::default();
 
         assert!(right.update_key(
-            &Key::Character("u".into()),
+            &PhysicalKey::Code(KeyCode::KeyU),
             ElementState::Pressed,
             &bindings.right_stick,
         ));
         assert_eq!(right.vector(), (-1.0, 0.0));
         assert!(!right.update_key(
-            &Key::Character("j".into()),
+            &PhysicalKey::Code(KeyCode::KeyJ),
             ElementState::Pressed,
             &bindings.right_stick,
         ));

--- a/emu/crates/frontend/src/main.rs
+++ b/emu/crates/frontend/src/main.rs
@@ -694,7 +694,6 @@ fn keycode_to_binding(code: KeyCode) -> Option<InputBinding> {
         KeyCode::F9 => named("F9"),
         KeyCode::F10 => named("F10"),
         KeyCode::F11 => named("F11"),
-        KeyCode::F12 => named("F12"),
         KeyCode::Numpad0 => named("Numpad0"),
         KeyCode::Numpad1 => named("Numpad1"),
         KeyCode::Numpad2 => named("Numpad2"),
@@ -728,8 +727,9 @@ fn keycode_to_binding(code: KeyCode) -> Option<InputBinding> {
         KeyCode::Backquote => named("Backquote"),
         KeyCode::IntlRo => named("IntlRo"),
         KeyCode::IntlBackslash => named("IntlBackslash"),
-        // Escape toggles the menu, F5/F7 are quick save/load: binding a
-        // pad button on top of those would fire both meanings at once.
+        // Escape toggles the menu, F5/F7 are quick save/load, and F12
+        // toggles the renderer display source. Keeping host commands out
+        // of pad bindings prevents one key press from firing both actions.
         _ => None,
     }
 }
@@ -875,8 +875,7 @@ impl ApplicationHandler for Shell {
                 // A controls-panel rebind capture owns the keyboard
                 // outright: the next key press becomes the binding
                 // (Escape cancels), and nothing leaks through to the
-                // game, the menu, or the hotkeys below -- binding "g"
-                // or F5 must not also fire their global meanings.
+                // game, the menu, or the host shortcuts below.
                 if let Some(target) = self.state.menu.controls_capture() {
                     if state == ElementState::Pressed && !repeat {
                         if matches!(logical_key, Key::Named(NamedKey::Escape)) {
@@ -947,16 +946,13 @@ impl ApplicationHandler for Shell {
                 if state == ElementState::Pressed {
                     self.pending_input = merge_key(self.pending_input, &logical_key);
                 }
-                // `g` -- toggle the display source between the CPU
+                // F12 -- toggle the display source between the CPU
                 // rasterizer's VRAM and the compute backend's. Only
                 // meaningful when the compute backend is active
                 // (i.e. `--gpu-compute` was passed). No-op otherwise.
-                // (Was F12; rebound to `g` so it needs no Fn on macOS.
-                // `g` is not a pad binding, so it never collides with play
-                // input.)
                 if state == ElementState::Pressed
                     && !repeat
-                    && matches!(&logical_key, Key::Character(c) if c.eq_ignore_ascii_case("g"))
+                    && matches!(&logical_key, Key::Named(NamedKey::F12))
                 {
                     self.display_gpu_compute = !self.display_gpu_compute;
                     eprintln!(
@@ -2440,7 +2436,7 @@ mod tests {
             KeyCode::Space,
             KeyCode::ShiftLeft,
             KeyCode::F1,
-            KeyCode::F12,
+            KeyCode::F11,
             KeyCode::Numpad0,
             KeyCode::Numpad9,
             KeyCode::NumpadAdd,
@@ -2457,8 +2453,16 @@ mod tests {
                 "{code:?} captured as {binding:?} but does not match back"
             );
         }
-        // Escape is reserved for the menu toggle.
-        assert_eq!(keycode_to_binding(KeyCode::Escape), None);
+        // Host commands are deliberately unavailable as pad bindings.
+        for code in [KeyCode::Escape, KeyCode::F5, KeyCode::F7, KeyCode::F12] {
+            assert_eq!(keycode_to_binding(code), None);
+        }
+        // The default Circle key must remain ordinary pad input rather than
+        // also toggling the renderer display source.
+        assert_eq!(
+            keycode_to_binding(KeyCode::KeyG),
+            Some(InputBinding::Character('g'))
+        );
     }
 
     #[test]

--- a/emu/crates/frontend/src/main.rs
+++ b/emu/crates/frontend/src/main.rs
@@ -391,6 +391,7 @@ fn key_to_pad_button(physical: &PhysicalKey, bindings: &PortBindings) -> Option<
         (button::START, &bindings.start),
         (button::SELECT, &bindings.select),
         (button::R3, &bindings.r3),
+        (button::L3, &bindings.l3),
     ]
     .into_iter()
     .find_map(|(mask, binding)| binding_matches_key(binding, physical).then_some(mask))
@@ -561,9 +562,12 @@ fn char_to_keycode(c: char) -> Option<KeyCode> {
 }
 
 /// Physical keycode(s) a persisted `InputBinding::Named` label matches.
-/// Mirrors the label set the old logical-key lookup accepted; "Shift"
-/// matches either physical shift key since the binding format predates
-/// left/right being distinguished.
+/// Covers the label set the old logical-key lookup accepted plus every
+/// label [`keycode_to_binding`] can produce for the controls panel's
+/// rebind capture (function keys, numpad -- prime real estate for
+/// dodging keyboard-matrix ghosting). "Shift" matches either physical
+/// shift key since the binding format predates left/right being
+/// distinguished.
 fn named_key_codes(name: &str) -> &'static [KeyCode] {
     match name.to_ascii_lowercase().as_str() {
         "arrowup" => &[KeyCode::ArrowUp],
@@ -576,8 +580,157 @@ fn named_key_codes(name: &str) -> &'static [KeyCode] {
         "space" => &[KeyCode::Space],
         "tab" => &[KeyCode::Tab],
         "escape" => &[KeyCode::Escape],
+        "f1" => &[KeyCode::F1],
+        "f2" => &[KeyCode::F2],
+        "f3" => &[KeyCode::F3],
+        "f4" => &[KeyCode::F4],
+        "f5" => &[KeyCode::F5],
+        "f6" => &[KeyCode::F6],
+        "f7" => &[KeyCode::F7],
+        "f8" => &[KeyCode::F8],
         "f9" => &[KeyCode::F9],
+        "f10" => &[KeyCode::F10],
+        "f11" => &[KeyCode::F11],
+        "f12" => &[KeyCode::F12],
+        "numpad0" => &[KeyCode::Numpad0],
+        "numpad1" => &[KeyCode::Numpad1],
+        "numpad2" => &[KeyCode::Numpad2],
+        "numpad3" => &[KeyCode::Numpad3],
+        "numpad4" => &[KeyCode::Numpad4],
+        "numpad5" => &[KeyCode::Numpad5],
+        "numpad6" => &[KeyCode::Numpad6],
+        "numpad7" => &[KeyCode::Numpad7],
+        "numpad8" => &[KeyCode::Numpad8],
+        "numpad9" => &[KeyCode::Numpad9],
+        "numpadadd" => &[KeyCode::NumpadAdd],
+        "numpadsubtract" => &[KeyCode::NumpadSubtract],
+        "numpadmultiply" => &[KeyCode::NumpadMultiply],
+        "numpaddivide" => &[KeyCode::NumpadDivide],
+        "numpaddecimal" => &[KeyCode::NumpadDecimal],
+        "numpadenter" => &[KeyCode::NumpadEnter],
+        "controlleft" => &[KeyCode::ControlLeft],
+        "controlright" => &[KeyCode::ControlRight],
+        "altleft" => &[KeyCode::AltLeft],
+        "altright" => &[KeyCode::AltRight],
+        "semicolon" => &[KeyCode::Semicolon],
+        "comma" => &[KeyCode::Comma],
+        "period" => &[KeyCode::Period],
+        "slash" => &[KeyCode::Slash],
+        "quote" => &[KeyCode::Quote],
+        "bracketleft" => &[KeyCode::BracketLeft],
+        "bracketright" => &[KeyCode::BracketRight],
+        "backslash" => &[KeyCode::Backslash],
+        "minus" => &[KeyCode::Minus],
+        "equal" => &[KeyCode::Equal],
+        "backquote" => &[KeyCode::Backquote],
+        "intlro" => &[KeyCode::IntlRo],
+        "intlbackslash" => &[KeyCode::IntlBackslash],
         _ => &[],
+    }
+}
+
+/// The persistable binding a captured physical key becomes -- the
+/// reverse of [`binding_matches_key`]'s lookup, used by the controls
+/// panel's press-a-key rebind flow. Letters and digits round-trip
+/// through the existing `Character` form; everything else gets a
+/// `Named` label that [`named_key_codes`] recognises. `None` means the
+/// key is not bindable: Escape stays reserved for the menu toggle, and
+/// keys outside the table have no stable label to persist.
+fn keycode_to_binding(code: KeyCode) -> Option<InputBinding> {
+    let named = |s: &str| Some(InputBinding::Named(s.to_string()));
+    let ch = |c: char| Some(InputBinding::Character(c));
+    match code {
+        KeyCode::KeyA => ch('a'),
+        KeyCode::KeyB => ch('b'),
+        KeyCode::KeyC => ch('c'),
+        KeyCode::KeyD => ch('d'),
+        KeyCode::KeyE => ch('e'),
+        KeyCode::KeyF => ch('f'),
+        KeyCode::KeyG => ch('g'),
+        KeyCode::KeyH => ch('h'),
+        KeyCode::KeyI => ch('i'),
+        KeyCode::KeyJ => ch('j'),
+        KeyCode::KeyK => ch('k'),
+        KeyCode::KeyL => ch('l'),
+        KeyCode::KeyM => ch('m'),
+        KeyCode::KeyN => ch('n'),
+        KeyCode::KeyO => ch('o'),
+        KeyCode::KeyP => ch('p'),
+        KeyCode::KeyQ => ch('q'),
+        KeyCode::KeyR => ch('r'),
+        KeyCode::KeyS => ch('s'),
+        KeyCode::KeyT => ch('t'),
+        KeyCode::KeyU => ch('u'),
+        KeyCode::KeyV => ch('v'),
+        KeyCode::KeyW => ch('w'),
+        KeyCode::KeyX => ch('x'),
+        KeyCode::KeyY => ch('y'),
+        KeyCode::KeyZ => ch('z'),
+        KeyCode::Digit0 => ch('0'),
+        KeyCode::Digit1 => ch('1'),
+        KeyCode::Digit2 => ch('2'),
+        KeyCode::Digit3 => ch('3'),
+        KeyCode::Digit4 => ch('4'),
+        KeyCode::Digit5 => ch('5'),
+        KeyCode::Digit6 => ch('6'),
+        KeyCode::Digit7 => ch('7'),
+        KeyCode::Digit8 => ch('8'),
+        KeyCode::Digit9 => ch('9'),
+        KeyCode::ArrowUp => named("ArrowUp"),
+        KeyCode::ArrowDown => named("ArrowDown"),
+        KeyCode::ArrowLeft => named("ArrowLeft"),
+        KeyCode::ArrowRight => named("ArrowRight"),
+        KeyCode::Enter => named("Enter"),
+        KeyCode::Backspace => named("Backspace"),
+        KeyCode::ShiftLeft | KeyCode::ShiftRight => named("Shift"),
+        KeyCode::Space => named("Space"),
+        KeyCode::Tab => named("Tab"),
+        KeyCode::F1 => named("F1"),
+        KeyCode::F2 => named("F2"),
+        KeyCode::F3 => named("F3"),
+        KeyCode::F4 => named("F4"),
+        KeyCode::F6 => named("F6"),
+        KeyCode::F8 => named("F8"),
+        KeyCode::F9 => named("F9"),
+        KeyCode::F10 => named("F10"),
+        KeyCode::F11 => named("F11"),
+        KeyCode::F12 => named("F12"),
+        KeyCode::Numpad0 => named("Numpad0"),
+        KeyCode::Numpad1 => named("Numpad1"),
+        KeyCode::Numpad2 => named("Numpad2"),
+        KeyCode::Numpad3 => named("Numpad3"),
+        KeyCode::Numpad4 => named("Numpad4"),
+        KeyCode::Numpad5 => named("Numpad5"),
+        KeyCode::Numpad6 => named("Numpad6"),
+        KeyCode::Numpad7 => named("Numpad7"),
+        KeyCode::Numpad8 => named("Numpad8"),
+        KeyCode::Numpad9 => named("Numpad9"),
+        KeyCode::NumpadAdd => named("NumpadAdd"),
+        KeyCode::NumpadSubtract => named("NumpadSubtract"),
+        KeyCode::NumpadMultiply => named("NumpadMultiply"),
+        KeyCode::NumpadDivide => named("NumpadDivide"),
+        KeyCode::NumpadDecimal => named("NumpadDecimal"),
+        KeyCode::NumpadEnter => named("NumpadEnter"),
+        KeyCode::ControlLeft => named("ControlLeft"),
+        KeyCode::ControlRight => named("ControlRight"),
+        KeyCode::AltLeft => named("AltLeft"),
+        KeyCode::AltRight => named("AltRight"),
+        KeyCode::Semicolon => named("Semicolon"),
+        KeyCode::Comma => named("Comma"),
+        KeyCode::Period => named("Period"),
+        KeyCode::Slash => named("Slash"),
+        KeyCode::Quote => named("Quote"),
+        KeyCode::BracketLeft => named("BracketLeft"),
+        KeyCode::BracketRight => named("BracketRight"),
+        KeyCode::Backslash => named("Backslash"),
+        KeyCode::Minus => named("Minus"),
+        KeyCode::Equal => named("Equal"),
+        KeyCode::Backquote => named("Backquote"),
+        KeyCode::IntlRo => named("IntlRo"),
+        KeyCode::IntlBackslash => named("IntlBackslash"),
+        // Escape toggles the menu, F5/F7 are quick save/load: binding a
+        // pad button on top of those would fire both meanings at once.
+        _ => None,
     }
 }
 
@@ -719,6 +872,33 @@ impl ApplicationHandler for Shell {
                     },
                 ..
             } => {
+                // A controls-panel rebind capture owns the keyboard
+                // outright: the next key press becomes the binding
+                // (Escape cancels), and nothing leaks through to the
+                // game, the menu, or the hotkeys below -- binding "g"
+                // or F5 must not also fire their global meanings.
+                if let Some(target) = self.state.menu.controls_capture() {
+                    if state == ElementState::Pressed && !repeat {
+                        if matches!(logical_key, Key::Named(NamedKey::Escape)) {
+                            self.state.menu.clear_controls_capture();
+                        } else if let PhysicalKey::Code(code) = physical_key {
+                            if let Some(binding) = keycode_to_binding(code) {
+                                self.state.apply_rebind(target, binding);
+                                self.state.menu.clear_controls_capture();
+                                // Drop held-key state: a key that was down
+                                // under its old meaning must not stay
+                                // wedged into the mask under the new one.
+                                self.pad1_mask = 0;
+                                self.keyboard_left_stick = KeyboardStickState::default();
+                                self.keyboard_right_stick = KeyboardStickState::default();
+                            } else {
+                                self.state
+                                    .status_message_set("That key can't be bound".to_string());
+                            }
+                        }
+                    }
+                    return;
+                }
                 // Pad state tracks both press AND release continuously
                 // so held buttons keep polling as "pressed". Auto-repeat
                 // events are ignored -- the key is already down, and the
@@ -2182,6 +2362,43 @@ mod tests {
             ),
             button::LEFT | button::DOWN | button::CROSS
         );
+    }
+
+    #[test]
+    fn captured_keys_round_trip_through_binding_match() {
+        // Every key the controls panel can capture must be recognised
+        // by the matcher afterwards, or a rebind would save a binding
+        // that never fires. Spot-check each table family: letters,
+        // digits, named keys, function keys, numpad.
+        for code in [
+            KeyCode::KeyA,
+            KeyCode::KeyZ,
+            KeyCode::Digit0,
+            KeyCode::Digit9,
+            KeyCode::ArrowLeft,
+            KeyCode::Enter,
+            KeyCode::Space,
+            KeyCode::ShiftLeft,
+            KeyCode::F1,
+            KeyCode::F12,
+            KeyCode::Numpad0,
+            KeyCode::Numpad9,
+            KeyCode::NumpadAdd,
+            KeyCode::NumpadEnter,
+            KeyCode::Semicolon,
+            KeyCode::Comma,
+            KeyCode::ControlLeft,
+            KeyCode::AltRight,
+        ] {
+            let binding =
+                keycode_to_binding(code).unwrap_or_else(|| panic!("{code:?} should be bindable"));
+            assert!(
+                binding_matches_key(&binding, &PhysicalKey::Code(code)),
+                "{code:?} captured as {binding:?} but does not match back"
+            );
+        }
+        // Escape is reserved for the menu toggle.
+        assert_eq!(keycode_to_binding(KeyCode::Escape), None);
     }
 
     #[test]

--- a/emu/crates/frontend/src/main.rs
+++ b/emu/crates/frontend/src/main.rs
@@ -1054,6 +1054,52 @@ impl ApplicationHandler for Shell {
                     self.socd_last_vert,
                 );
 
+                // Feed the controls panel its live held-target set so
+                // held keys light up on the drawing -- an in-app
+                // rollover/ghosting tester. Only while it's open; the
+                // Vec is rebuilt per frame but tops out at 25 entries.
+                if self.state.menu.controls_panel_open() {
+                    use crate::ui::menu::PadBindTarget as T;
+                    let mut held = Vec::new();
+                    for (bit, target) in [
+                        (button::UP, T::Up),
+                        (button::DOWN, T::Down),
+                        (button::LEFT, T::Left),
+                        (button::RIGHT, T::Right),
+                        (button::CROSS, T::Cross),
+                        (button::CIRCLE, T::Circle),
+                        (button::SQUARE, T::Square),
+                        (button::TRIANGLE, T::Triangle),
+                        (button::L1, T::L1),
+                        (button::L2, T::L2),
+                        (button::R1, T::R1),
+                        (button::R2, T::R2),
+                        (button::START, T::Start),
+                        (button::SELECT, T::Select),
+                        (button::L3, T::L3),
+                        (button::R3, T::R3),
+                    ] {
+                        if merged_mask & bit != 0 {
+                            held.push(target);
+                        }
+                    }
+                    for (on, target) in [
+                        (self.keyboard_left_stick.up, T::LStickUp),
+                        (self.keyboard_left_stick.down, T::LStickDown),
+                        (self.keyboard_left_stick.left, T::LStickLeft),
+                        (self.keyboard_left_stick.right, T::LStickRight),
+                        (self.keyboard_right_stick.up, T::RStickUp),
+                        (self.keyboard_right_stick.down, T::RStickDown),
+                        (self.keyboard_right_stick.left, T::RStickLeft),
+                        (self.keyboard_right_stick.right, T::RStickRight),
+                    ] {
+                        if on {
+                            held.push(target);
+                        }
+                    }
+                    self.state.menu.set_controls_live_held(held);
+                }
+
                 // Gamepad input arrives by polling, not as window events,
                 // so it cannot wake the redraw scheduler the way keyboard
                 // and mouse do. Remember when the pad was last live; the
@@ -1114,10 +1160,20 @@ impl ApplicationHandler for Shell {
                 if input.toggle_open {
                     input.toggle_open = false;
                     input.back = false;
+                    // With the controls panel up, Escape means "close
+                    // the panel", not "toggle the whole menu" -- the
+                    // nearest thing on screen should dismiss first.
+                    // (A pending key capture never reaches here: the
+                    // capture arm consumes Escape as its cancel.)
+                    let closed_controls_panel = self.state.menu.controls_panel_open() && {
+                        self.state.menu.close_controls();
+                        true
+                    };
                     // In the editor, Escape first releases an active embedded-play
                     // input capture instead of toggling the menu.
                     #[cfg(feature = "editor")]
-                    let editor_released_capture = self.state.workspace.is_editor()
+                    let editor_released_capture = !closed_controls_panel
+                        && self.state.workspace.is_editor()
                         && self.state.embedded_playtest_running()
                         && self.state.embedded_playtest_input_captured()
                         && {
@@ -1126,7 +1182,7 @@ impl ApplicationHandler for Shell {
                         };
                     #[cfg(not(feature = "editor"))]
                     let editor_released_capture = false;
-                    if editor_released_capture {
+                    if closed_controls_panel || editor_released_capture {
                         // Handled above: input capture released.
                     } else if self.state.running {
                         // Game mode → menu mode: pause and open overlay.
@@ -2271,16 +2327,20 @@ mod tests {
         let bindings = PortBindings::default();
 
         assert_eq!(
-            key_to_pad_button(&PhysicalKey::Code(KeyCode::KeyX), &bindings),
+            key_to_pad_button(&PhysicalKey::Code(KeyCode::KeyF), &bindings),
             Some(button::CROSS)
         );
         assert_eq!(
-            key_to_pad_button(&PhysicalKey::Code(KeyCode::KeyC), &bindings),
+            key_to_pad_button(&PhysicalKey::Code(KeyCode::KeyG), &bindings),
             Some(button::CIRCLE)
         );
         assert_eq!(
-            key_to_pad_button(&PhysicalKey::Code(KeyCode::KeyZ), &bindings),
+            key_to_pad_button(&PhysicalKey::Code(KeyCode::KeyH), &bindings),
             Some(button::SQUARE)
+        );
+        assert_eq!(
+            key_to_pad_button(&PhysicalKey::Code(KeyCode::KeyX), &bindings),
+            Some(button::TRIANGLE)
         );
         assert_eq!(
             key_to_pad_button(&PhysicalKey::Code(KeyCode::Backspace), &bindings),
@@ -2412,8 +2472,9 @@ mod tests {
             key_to_pad_button(&PhysicalKey::Code(KeyCode::KeyJ), &bindings),
             Some(button::CROSS)
         );
+        // Cross's default key (F) no longer maps to anything.
         assert_eq!(
-            key_to_pad_button(&PhysicalKey::Code(KeyCode::KeyX), &bindings),
+            key_to_pad_button(&PhysicalKey::Code(KeyCode::KeyF), &bindings),
             None
         );
     }

--- a/emu/crates/frontend/src/main.rs
+++ b/emu/crates/frontend/src/main.rs
@@ -190,31 +190,15 @@ struct Shell {
     state: AppState,
     pending_input: MenuInput,
     last_frame: Instant,
-    /// Live port-1 pad mask. Key press/release events toggle bits
-    /// here; the shell flushes it into `bus.set_port1_buttons` each
-    /// frame before running CPU steps so the guest always sees the
-    /// latest state.
-    pad1_mask: u16,
-    /// Most recently *pressed* button of the LEFT/RIGHT pair, for SOCD
-    /// (simultaneous opposing cardinal directions) resolution. The real
-    /// PS1 d-pad is a physical rocker -- left+right can never be down
-    /// together, so games were never written for both bits set and react
-    /// unpredictably (most just keep the old direction). A keyboard makes
-    /// the combination trivial to produce, so when both are held the mask
-    /// sent to the guest keeps only the most recent press; releasing it
-    /// re-exposes the still-held opposite. Last-input-priority matches
-    /// what a player expects from tapping the other direction without
-    /// letting go first.
-    socd_last_horiz: u16,
-    /// Same, for the UP/DOWN pair.
-    socd_last_vert: u16,
+    /// Every piece of pad state the shell derives from keyboard events
+    /// (button mask, emulated sticks, SOCD recency). One struct so the
+    /// paths that must invalidate it wholesale -- focus loss, a rebind
+    /// capture consuming events, Reset Controls -- clear one thing and
+    /// can't miss a field.
+    host_input: HostKeyboardInput,
     /// Previous-frame state of the L3+R3 freelook chord, for rising-edge
     /// toggle detection.
     prev_freelook_chord: bool,
-    /// Keyboard-emulated left analog stick state.
-    keyboard_left_stick: KeyboardStickState,
-    /// Keyboard-emulated right analog stick state.
-    keyboard_right_stick: KeyboardStickState,
     /// Whether to open the window in borderless-fullscreen mode.
     /// Decision is made at startup via CLI flag and then captured
     /// here; changing it at runtime would need a window recreation.
@@ -326,12 +310,8 @@ impl Shell {
             state: AppState::with_config_dir(config_dir),
             pending_input: MenuInput::default(),
             last_frame: Instant::now(),
-            pad1_mask: 0,
-            socd_last_horiz: 0,
-            socd_last_vert: 0,
+            host_input: HostKeyboardInput::default(),
             prev_freelook_chord: false,
-            keyboard_left_stick: KeyboardStickState::default(),
-            keyboard_right_stick: KeyboardStickState::default(),
             fullscreen,
             audio,
             input,
@@ -471,7 +451,7 @@ fn merge_axis(gamepad: f32, keyboard: f32) -> f32 {
 
 /// Strip simultaneous opposing cardinal directions from the pad mask,
 /// keeping only the most recently pressed side of each pair (see
-/// `Shell::socd_last_horiz`). The real d-pad's rocker makes the
+/// [`HostKeyboardInput`]). The real d-pad's rocker makes the
 /// combination impossible, so the guest must never see it; with no
 /// recorded recency (or a stale one no longer held) the pair resolves
 /// to neutral, which is what the rocker does mid-travel.
@@ -486,6 +466,119 @@ fn socd_resolve(mask: u16, last_horiz: u16, last_vert: u16) -> u16 {
         out = (out & !VERT) | (last_vert & VERT);
     }
     out
+}
+
+/// Fold a set of rising-edge presses into the SOCD recency trackers.
+/// Shared by the keyboard press path (one button bit per event) and
+/// the gamepad path (a whole poll's edges at once) so both devices
+/// compete on equal terms -- a newer gamepad direction must beat an
+/// older keyboard one and vice versa. Opposite edges arriving in the
+/// same gamepad poll carry no ordering information, so the pair's
+/// recency resets and [`socd_resolve`] yields neutral.
+fn update_socd_recency(last_horiz: &mut u16, last_vert: &mut u16, pressed: u16) {
+    const HORIZ: u16 = button::LEFT | button::RIGHT;
+    const VERT: u16 = button::UP | button::DOWN;
+    match pressed & HORIZ {
+        button::LEFT => *last_horiz = button::LEFT,
+        button::RIGHT => *last_horiz = button::RIGHT,
+        HORIZ => *last_horiz = 0,
+        _ => {}
+    }
+    match pressed & VERT {
+        button::UP => *last_vert = button::UP,
+        button::DOWN => *last_vert = button::DOWN,
+        VERT => *last_vert = 0,
+        _ => {}
+    }
+}
+
+/// Every piece of pad state derived from host keyboard events: the
+/// port-1 button mask, both keyboard-emulated sticks, and the SOCD
+/// recency trackers.
+///
+/// Grouped so the paths that must throw the whole cache away clear one
+/// struct and can't miss a field. That matters because this state is
+/// only correct while every key release is observed and the bindings
+/// that produced it are still live; three paths break that assumption:
+///
+/// - **focus loss** -- the OS doesn't reliably deliver `Released` for
+///   keys still held during Alt-Tab;
+/// - **a rebind capture consuming events** -- capture owns the
+///   keyboard outright, including releases whose normal processing
+///   would have cleared held bits;
+/// - **Reset Controls** -- bits set under the old bindings can never
+///   be cleared by releases matched against the new ones.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct HostKeyboardInput {
+    /// Live port-1 pad mask. Key press/release events toggle bits
+    /// here; the shell merges it with the gamepad mask each frame.
+    pad1_mask: u16,
+    /// Keyboard-emulated left analog stick state.
+    left_stick: KeyboardStickState,
+    /// Keyboard-emulated right analog stick state.
+    right_stick: KeyboardStickState,
+    /// Most recently pressed button of the LEFT/RIGHT pair, for SOCD
+    /// (simultaneous opposing cardinal directions) resolution: when
+    /// both are held the guest sees only the most recent press, and
+    /// releasing it re-exposes the still-held opposite. Last-input
+    /// priority matches what a player expects from tapping the other
+    /// direction without letting go first.
+    socd_last_horiz: u16,
+    /// Same, for the UP/DOWN pair.
+    socd_last_vert: u16,
+}
+
+impl HostKeyboardInput {
+    /// Drop everything: mask, sticks, and SOCD recency. The pad
+    /// simply reports "nothing held" until fresh key events arrive.
+    fn clear(&mut self) {
+        *self = Self::default();
+    }
+
+    /// Apply one keyboard press/release to the cached pad state:
+    /// button mask (with SOCD recency on presses) and both emulated
+    /// sticks.
+    fn apply_key_event(
+        &mut self,
+        physical: &PhysicalKey,
+        state: ElementState,
+        bindings: &PortBindings,
+    ) {
+        if let Some(mask) = key_to_pad_button(physical, bindings) {
+            match state {
+                ElementState::Pressed => {
+                    self.pad1_mask |= mask;
+                    update_socd_recency(&mut self.socd_last_horiz, &mut self.socd_last_vert, mask);
+                }
+                ElementState::Released => self.pad1_mask &= !mask,
+            }
+        }
+        self.left_stick
+            .update_key(physical, state, &bindings.left_stick);
+        self.right_stick
+            .update_key(physical, state, &bindings.right_stick);
+    }
+
+    /// Fold the gamepad's rising-edge presses from this poll into the
+    /// SOCD recency, so a newer pad direction beats an older keyboard
+    /// one. Call before [`Self::resolved_mask`] each frame.
+    fn note_gamepad_edges(&mut self, pressed_mask: u16) {
+        update_socd_recency(
+            &mut self.socd_last_horiz,
+            &mut self.socd_last_vert,
+            pressed_mask,
+        );
+    }
+
+    /// The SOCD-clean guest mask: keyboard bits merged with the
+    /// gamepad's, opposing cardinals resolved by recency.
+    fn resolved_mask(&self, gamepad_mask: u16) -> u16 {
+        socd_resolve(
+            self.pad1_mask | gamepad_mask,
+            self.socd_last_horiz,
+            self.socd_last_vert,
+        )
+    }
 }
 
 /// Match a persisted binding against the *physical* key that changed,
@@ -856,9 +949,7 @@ impl ApplicationHandler for Shell {
             // simply reports "nothing held" until the player presses
             // fresh keys after refocusing.
             WindowEvent::Focused(false) => {
-                self.pad1_mask = 0;
-                self.keyboard_left_stick = KeyboardStickState::default();
-                self.keyboard_right_stick = KeyboardStickState::default();
+                self.host_input.clear();
             }
             WindowEvent::Focused(true) => {}
             WindowEvent::KeyboardInput {
@@ -877,6 +968,13 @@ impl ApplicationHandler for Shell {
                 // (Escape cancels), and nothing leaks through to the
                 // game, the menu, or the host shortcuts below.
                 if let Some(target) = self.state.menu.controls_capture() {
+                    // Capture consumes this event unconditionally --
+                    // including releases, whose normal processing is
+                    // what clears held bits. Drop the cached keyboard
+                    // state up front so no exit from capture (bind,
+                    // Escape, closing the panel) can leave a swallowed
+                    // release's button wedged into the mask.
+                    self.host_input.clear();
                     if state == ElementState::Pressed && !repeat {
                         if matches!(logical_key, Key::Named(NamedKey::Escape)) {
                             self.state.menu.clear_controls_capture();
@@ -884,12 +982,6 @@ impl ApplicationHandler for Shell {
                             if let Some(binding) = keycode_to_binding(code) {
                                 self.state.apply_rebind(target, binding);
                                 self.state.menu.clear_controls_capture();
-                                // Drop held-key state: a key that was down
-                                // under its old meaning must not stay
-                                // wedged into the mask under the new one.
-                                self.pad1_mask = 0;
-                                self.keyboard_left_stick = KeyboardStickState::default();
-                                self.keyboard_right_stick = KeyboardStickState::default();
                             } else {
                                 self.state
                                     .status_message_set("That key can't be bound".to_string());
@@ -911,27 +1003,8 @@ impl ApplicationHandler for Shell {
                 let route_keyboard_to_game = true;
                 if !repeat && route_keyboard_to_game {
                     let bindings = &self.state.settings.input.port1;
-                    if let Some(mask) = key_to_pad_button(&physical_key, bindings) {
-                        match state {
-                            ElementState::Pressed => {
-                                self.pad1_mask |= mask;
-                                if mask & (button::LEFT | button::RIGHT) != 0 {
-                                    self.socd_last_horiz = mask;
-                                }
-                                if mask & (button::UP | button::DOWN) != 0 {
-                                    self.socd_last_vert = mask;
-                                }
-                            }
-                            ElementState::Released => self.pad1_mask &= !mask,
-                        }
-                    }
-                    self.keyboard_left_stick
-                        .update_key(&physical_key, state, &bindings.left_stick);
-                    self.keyboard_right_stick.update_key(
-                        &physical_key,
-                        state,
-                        &bindings.right_stick,
-                    );
+                    self.host_input
+                        .apply_key_event(&physical_key, state, bindings);
                     let press_analog = state == ElementState::Pressed
                         && key_is_analog_button(&physical_key, bindings);
                     if press_analog {
@@ -1039,16 +1112,18 @@ impl ApplicationHandler for Shell {
 
                 // Merge keyboard-emulated and real-pad sticks once; used both
                 // to drive the freelook camera and (unless freelook steals
-                // them) to feed the guest pad below.
-                let merged_left =
-                    merge_sticks(pad_frame.left_stick, self.keyboard_left_stick.vector());
-                let merged_right =
-                    merge_sticks(pad_frame.right_stick, self.keyboard_right_stick.vector());
-                let merged_mask = socd_resolve(
-                    self.pad1_mask | pad_frame.pad1_mask,
-                    self.socd_last_horiz,
-                    self.socd_last_vert,
-                );
+                // them) to feed the guest pad below. The gamepad's press
+                // edges fold into SOCD recency *before* resolving, so a
+                // newer pad direction beats an older keyboard one. All
+                // three are `mut`: a menu action that invalidates cached
+                // keyboard input (Reset Controls) rebuilds them below so
+                // the reset frame can't ship stale keyboard state.
+                self.host_input.note_gamepad_edges(pad_frame.pressed_mask);
+                let mut merged_left =
+                    merge_sticks(pad_frame.left_stick, self.host_input.left_stick.vector());
+                let mut merged_right =
+                    merge_sticks(pad_frame.right_stick, self.host_input.right_stick.vector());
+                let mut merged_mask = self.host_input.resolved_mask(pad_frame.pad1_mask);
 
                 // Feed the controls panel its live held-target set so
                 // held keys light up on the drawing -- an in-app
@@ -1080,14 +1155,14 @@ impl ApplicationHandler for Shell {
                         }
                     }
                     for (on, target) in [
-                        (self.keyboard_left_stick.up, T::LStickUp),
-                        (self.keyboard_left_stick.down, T::LStickDown),
-                        (self.keyboard_left_stick.left, T::LStickLeft),
-                        (self.keyboard_left_stick.right, T::LStickRight),
-                        (self.keyboard_right_stick.up, T::RStickUp),
-                        (self.keyboard_right_stick.down, T::RStickDown),
-                        (self.keyboard_right_stick.left, T::RStickLeft),
-                        (self.keyboard_right_stick.right, T::RStickRight),
+                        (self.host_input.left_stick.up, T::LStickUp),
+                        (self.host_input.left_stick.down, T::LStickDown),
+                        (self.host_input.left_stick.left, T::LStickLeft),
+                        (self.host_input.left_stick.right, T::LStickRight),
+                        (self.host_input.right_stick.up, T::RStickUp),
+                        (self.host_input.right_stick.down, T::RStickDown),
+                        (self.host_input.right_stick.left, T::RStickLeft),
+                        (self.host_input.right_stick.right, T::RStickRight),
                     ] {
                         if on {
                             held.push(target);
@@ -1208,22 +1283,38 @@ impl ApplicationHandler for Shell {
                 }
 
                 if let Some(action) = self.state.menu.update(&input) {
-                    if ui::apply_menu_action(&mut self.state, action) == MenuOutcome::Quit {
-                        #[cfg(feature = "editor")]
-                        self.state.stop_embedded_playtest();
-                        self.state.stop_examples_build();
-                        if let Err(e) = self.state.flush_memcard_port1() {
-                            eprintln!("[frontend] memcard flush on quit: {e}");
+                    match ui::apply_menu_action(&mut self.state, action) {
+                        MenuOutcome::None => {}
+                        MenuOutcome::ClearHostKeyboardInput => {
+                            // The action (Reset Controls) replaced the
+                            // bindings, so every cached keyboard bit was
+                            // set under a mapping that no longer exists
+                            // -- a later release can't clear it. Drop
+                            // the cache and rebuild this frame's merged
+                            // sample from the gamepad alone, so not even
+                            // one stale keyboard frame reaches the guest.
+                            self.host_input.clear();
+                            merged_mask = self.host_input.resolved_mask(pad_frame.pad1_mask);
+                            merged_left = pad_frame.left_stick;
+                            merged_right = pad_frame.right_stick;
                         }
-                        #[cfg(feature = "editor")]
-                        if let Err(e) = self.state.save_editor_project() {
-                            eprintln!("[frontend] editor save on quit: {e}");
+                        MenuOutcome::Quit => {
+                            #[cfg(feature = "editor")]
+                            self.state.stop_embedded_playtest();
+                            self.state.stop_examples_build();
+                            if let Err(e) = self.state.flush_memcard_port1() {
+                                eprintln!("[frontend] memcard flush on quit: {e}");
+                            }
+                            #[cfg(feature = "editor")]
+                            if let Err(e) = self.state.save_editor_project() {
+                                eprintln!("[frontend] editor save on quit: {e}");
+                            }
+                            if let Err(e) = self.state.save_settings() {
+                                eprintln!("[frontend] settings save on quit: {e}");
+                            }
+                            event_loop.exit();
+                            return;
                         }
-                        if let Err(e) = self.state.save_settings() {
-                            eprintln!("[frontend] settings save on quit: {e}");
-                        }
-                        event_loop.exit();
-                        return;
                     }
                 }
                 #[cfg(feature = "editor")]
@@ -2417,6 +2508,137 @@ mod tests {
                 button::DOWN,
             ),
             button::LEFT | button::DOWN | button::CROSS
+        );
+    }
+
+    /// One keyboard press applied through the full event path.
+    fn press(host: &mut HostKeyboardInput, code: KeyCode, bindings: &PortBindings) {
+        host.apply_key_event(&PhysicalKey::Code(code), ElementState::Pressed, bindings);
+    }
+
+    /// One keyboard release applied through the full event path.
+    fn release(host: &mut HostKeyboardInput, code: KeyCode, bindings: &PortBindings) {
+        host.apply_key_event(&PhysicalKey::Code(code), ElementState::Released, bindings);
+    }
+
+    #[test]
+    fn capture_swallowed_release_cannot_wedge_pad_state() {
+        // Regression for: hold a bound key while the game runs, arm a
+        // rebind capture, release the key while capture owns the
+        // keyboard, then cancel with Escape (or close the panel). The
+        // release is consumed by the capture branch, so its normal
+        // processing never clears the bit -- the capture branch must
+        // clear the whole cache on every event it consumes instead.
+        let bindings = PortBindings::default();
+        let mut host = HostKeyboardInput::default();
+
+        // Hold Cross (default F) -- its bit and stick state are live.
+        press(&mut host, KeyCode::KeyF, &bindings);
+        assert_eq!(host.resolved_mask(0), button::CROSS);
+
+        // A capture armed now consumes every event, starting with the
+        // release of F. The shell clears the cache for each consumed
+        // event; the swallowed release therefore cannot strand its bit,
+        // regardless of how capture ends (bind / Escape / panel close).
+        host.clear();
+        assert_eq!(host, HostKeyboardInput::default());
+        assert_eq!(host.resolved_mask(0), 0);
+
+        // A stray release arriving after capture ends (key already up)
+        // stays a no-op.
+        release(&mut host, KeyCode::KeyF, &bindings);
+        assert_eq!(host.resolved_mask(0), 0);
+
+        // Focus loss and a successful rebind route through the same
+        // clear() -- the invariant is identical: everything neutral,
+        // including SOCD recency.
+        press(&mut host, KeyCode::ArrowLeft, &bindings);
+        assert_ne!(host.socd_last_horiz, 0);
+        host.clear();
+        assert_eq!(host.socd_last_horiz, 0);
+        assert_eq!(host.resolved_mask(0), 0);
+    }
+
+    #[test]
+    fn reset_controls_invalidates_bits_from_the_old_bindings() {
+        // Regression for: bind Circle to J, hold J, click Reset
+        // Controls, release J. After the reset J no longer matches
+        // Circle, so its release can't clear the stale bit -- the
+        // reset path must drop the cache outright, while gamepad
+        // input (merged separately) is preserved.
+        let custom = PortBindings {
+            circle: InputBinding::Character('j'),
+            ..PortBindings::default()
+        };
+        let mut host = HostKeyboardInput::default();
+
+        press(&mut host, KeyCode::KeyJ, &custom);
+        assert_eq!(host.resolved_mask(0), button::CIRCLE);
+
+        // Reset Controls: MenuOutcome::ClearHostKeyboardInput makes the
+        // shell clear the cache and rebuild the frame's merged sample
+        // from the gamepad alone.
+        let defaults = PortBindings::default();
+        host.clear();
+        let gamepad_mask = button::L1;
+        assert_eq!(host.resolved_mask(gamepad_mask), button::L1);
+
+        // The release under the *new* bindings no longer maps to
+        // Circle (J is a right-stick direction in the defaults) and
+        // must not resurrect anything.
+        release(&mut host, KeyCode::KeyJ, &defaults);
+        assert_eq!(host.resolved_mask(gamepad_mask), button::L1);
+    }
+
+    #[test]
+    fn socd_recency_lets_the_newer_device_win() {
+        let bindings = PortBindings::default();
+
+        // Keyboard Left held, then gamepad Right pressed: the gamepad
+        // edge updates recency, so Right wins the merged clash.
+        let mut host = HostKeyboardInput::default();
+        press(&mut host, KeyCode::ArrowLeft, &bindings);
+        host.note_gamepad_edges(button::RIGHT);
+        assert_eq!(
+            host.resolved_mask(button::RIGHT) & (button::LEFT | button::RIGHT),
+            button::RIGHT
+        );
+
+        // Gamepad Left held (edge noted earlier), then keyboard Right
+        // pressed: the keyboard press updates recency, Right wins.
+        let mut host = HostKeyboardInput::default();
+        host.note_gamepad_edges(button::LEFT);
+        press(&mut host, KeyCode::ArrowRight, &bindings);
+        assert_eq!(
+            host.resolved_mask(button::LEFT) & (button::LEFT | button::RIGHT),
+            button::RIGHT
+        );
+
+        // Releasing the winner re-exposes the still-held opposite: the
+        // resolver only intervenes while both bits are actually down.
+        release(&mut host, KeyCode::ArrowRight, &bindings);
+        assert_eq!(
+            host.resolved_mask(button::LEFT) & (button::LEFT | button::RIGHT),
+            button::LEFT
+        );
+
+        // Opposite edges in the same gamepad poll carry no ordering
+        // information: recency resets and the pair resolves neutral.
+        let mut host = HostKeyboardInput::default();
+        press(&mut host, KeyCode::ArrowLeft, &bindings);
+        host.note_gamepad_edges(button::LEFT | button::RIGHT);
+        assert_eq!(
+            host.resolved_mask(button::LEFT | button::RIGHT) & (button::LEFT | button::RIGHT),
+            0
+        );
+
+        // The vertical pair tracks independently through the same path.
+        let mut host = HostKeyboardInput::default();
+        press(&mut host, KeyCode::ArrowUp, &bindings);
+        host.note_gamepad_edges(button::DOWN);
+        assert_eq!(
+            host.resolved_mask(button::DOWN) & (button::UP | button::DOWN),
+            button::DOWN
         );
     }
 

--- a/emu/crates/frontend/src/ui/menu.rs
+++ b/emu/crates/frontend/src/ui/menu.rs
@@ -311,6 +311,10 @@ pub struct MenuState {
     /// Current binding label per target, synced from the app layer via
     /// [`MenuState::sync_controls`] whenever a binding changes.
     controls_labels: HashMap<PadBindTarget, String>,
+    /// Targets whose key is physically held right now, synced by the
+    /// shell each frame while the panel is open. Drives the panel's
+    /// green held-highlights (a live rollover/ghosting tester).
+    controls_live_held: Vec<PadBindTarget>,
     pending_pointer_action: Option<MenuAction>,
     categories: Vec<Category>,
 }
@@ -438,6 +442,7 @@ impl MenuState {
             controls_open: false,
             controls_capture: None,
             controls_labels: HashMap::new(),
+            controls_live_held: Vec::new(),
             pending_pointer_action: None,
             categories,
         }
@@ -566,6 +571,25 @@ impl MenuState {
     /// Disarm the pending capture (key consumed or Escape pressed).
     pub fn clear_controls_capture(&mut self) {
         self.controls_capture = None;
+    }
+
+    /// Whether the controls panel is currently showing -- the shell
+    /// checks this to route Escape to "close panel" instead of the
+    /// menu toggle, and to skip the live-held sync when it's not up.
+    pub fn controls_panel_open(&self) -> bool {
+        self.controls_open
+    }
+
+    /// Close the controls panel, disarming any pending capture.
+    pub fn close_controls(&mut self) {
+        self.controls_open = false;
+        self.controls_capture = None;
+    }
+
+    /// Replace the live held-target set the panel highlights. Synced
+    /// by the shell each frame while the panel is open.
+    pub fn set_controls_live_held(&mut self, held: Vec<PadBindTarget>) {
+        self.controls_live_held = held;
     }
 
     /// Store the menu-backdrop opacity (percent) and reflect it in the
@@ -748,6 +772,7 @@ impl MenuState {
                 ctx,
                 &mut self.controls_open,
                 &self.controls_labels,
+                &self.controls_live_held,
                 &mut self.controls_capture,
                 &mut self.pending_pointer_action,
             );
@@ -1487,9 +1512,13 @@ fn save_states_panel(
 }
 
 /// The controls panel: a painter-drawn PS1 controller whose parts are
-/// clickable rebind hotspots, a full clickable list of every target
-/// below it (the drawing is the fast path, the list is the complete
-/// one), a live capture banner, and a reset-to-defaults button.
+/// clickable rebind hotspots -- each showing its current key right on
+/// the drawing -- plus a grouped clickable list of every target below
+/// it, a live capture banner, and a reset-to-defaults button.
+///
+/// Controls light up green while their key is physically held, which
+/// doubles as an in-app rollover/ghosting tester: hold three keys and
+/// see exactly which ones the keyboard actually delivered.
 ///
 /// Rebinds don't go through [`MenuAction`]: clicking a hotspot arms
 /// `capture`, and the shell's keyboard handler consumes the next
@@ -1500,20 +1529,34 @@ fn controls_panel(
     ctx: &egui::Context,
     open: &mut bool,
     labels: &HashMap<PadBindTarget, String>,
+    held: &[PadBindTarget],
     capture: &mut Option<PadBindTarget>,
     pending_pointer_action: &mut Option<MenuAction>,
 ) {
     use egui::{Color32, CornerRadius, Sense, Stroke};
 
-    const CANVAS: Vec2 = Vec2::new(470.0, 260.0);
+    const CANVAS: Vec2 = Vec2::new(470.0, 300.0);
     let bind_of =
         |t: PadBindTarget| -> String { labels.get(&t).cloned().unwrap_or_else(|| "-".to_string()) };
+    // Space on the drawing is tight; long names ("NumpadSubtract")
+    // elide there but stay complete in the list and hover text.
+    let short_bind = |t: PadBindTarget| -> String {
+        let full = bind_of(t);
+        if full.chars().count() > 7 {
+            let head: String = full.chars().take(6).collect();
+            format!("{head}\u{2026}")
+        } else {
+            full
+        }
+    };
 
-    // While a capture is armed, keep frames coming: the pulse ring and
-    // the "press a key" banner animate, and the upstream render-on-
-    // change pacing would otherwise freeze them between inputs.
+    // Keep frames coming while the panel is up: the capture pulse
+    // animates, and the held-key highlights must track key releases
+    // even when the paused game isn't producing new frames itself.
     if capture.is_some() {
         ctx.request_repaint_after(std::time::Duration::from_millis(50));
+    } else {
+        ctx.request_repaint_after(std::time::Duration::from_millis(120));
     }
 
     let mut still_open = *open;
@@ -1539,8 +1582,8 @@ fn controls_panel(
                 None => {
                     ui.label(
                         egui::RichText::new(
-                            "Click a control, then press the key to bind it. \
-                             Changes apply immediately and are saved.",
+                            "Click a control, then press the key to bind it. Changes apply \
+                             immediately and are saved. Held keys light up green.",
                         )
                         .color(theme::MENU_TEXT_DIM)
                         .size(12.0),
@@ -1556,15 +1599,28 @@ fn controls_panel(
             let pulse = ((ui.input(|i| i.time) * std::f64::consts::TAU).sin() * 0.5 + 0.5) as f32;
 
             let body_fill = Color32::from_rgb(52, 56, 64);
-            let body_edge = Stroke::new(1.5, Color32::from_rgb(90, 96, 108));
+            let body_hilight = Color32::from_rgb(64, 69, 79);
             let btn_fill = Color32::from_rgb(34, 37, 43);
+            let held_fill = Color32::from_rgba_unmultiplied(70, 190, 110, 70);
+            let held_ring = Stroke::new(2.0, Color32::from_rgb(80, 210, 120));
+            let bind_text = Color32::from_rgb(150, 200, 235);
 
-            // One clickable region. Paints a hover/armed ring, shows the
-            // current bind as hover text, and arms the capture on click.
+            // One clickable region. Paints a held/hover/armed ring,
+            // shows the current bind as hover text, and arms the
+            // capture on click.
             let mut hotspot = |ui: &mut egui::Ui, rect: Rect, target: PadBindTarget| {
                 let id = resp.id.with(target.label());
                 let r = ui.interact(rect, id, Sense::click());
                 let armed = *capture == Some(target);
+                if held.contains(&target) {
+                    ui.painter().rect_filled(rect, 4.0, held_fill);
+                    ui.painter().rect_stroke(
+                        rect.expand(1.0),
+                        4.0,
+                        held_ring,
+                        egui::StrokeKind::Outside,
+                    );
+                }
                 if armed {
                     let ring = Color32::from_rgb(
                         60 + (170.0 * pulse) as u8,
@@ -1595,85 +1651,108 @@ fn controls_panel(
                 }
             };
 
-            // Controller body: main slab + two grips.
-            painter.rect_filled(
-                Rect::from_min_max(at(30.0, 70.0), at(440.0, 185.0)),
-                CornerRadius::same(26),
+            // Controller body: two rounded wings bridged in the middle,
+            // grips flaring down-outward -- the PS1 silhouette.
+            let left_wing = Rect::from_min_max(at(22.0, 62.0), at(195.0, 185.0));
+            let right_wing = Rect::from_min_max(at(275.0, 62.0), at(448.0, 185.0));
+            let bridge = Rect::from_min_max(at(150.0, 72.0), at(320.0, 172.0));
+            painter.rect_filled(left_wing, CornerRadius::same(34), body_fill);
+            painter.rect_filled(right_wing, CornerRadius::same(34), body_fill);
+            painter.rect_filled(bridge, CornerRadius::same(16), body_fill);
+            // Grips: angled quads continuing the wings downward.
+            painter.add(egui::Shape::convex_polygon(
+                vec![
+                    at(40.0, 150.0),
+                    at(120.0, 170.0),
+                    at(105.0, 262.0),
+                    at(38.0, 240.0),
+                ],
                 body_fill,
-            );
-            painter.rect_filled(
-                Rect::from_min_max(at(30.0, 130.0), at(120.0, 240.0)),
-                CornerRadius::same(30),
+                Stroke::NONE,
+            ));
+            painter.add(egui::Shape::convex_polygon(
+                vec![
+                    at(350.0, 170.0),
+                    at(430.0, 150.0),
+                    at(432.0, 240.0),
+                    at(365.0, 262.0),
+                ],
                 body_fill,
-            );
+                Stroke::NONE,
+            ));
+            // Subtle top sheen so the slab reads as a molded shell.
             painter.rect_filled(
-                Rect::from_min_max(at(350.0, 130.0), at(440.0, 240.0)),
-                CornerRadius::same(30),
-                body_fill,
+                Rect::from_min_max(at(34.0, 68.0), at(436.0, 82.0)),
+                CornerRadius::same(7),
+                body_hilight,
             );
 
-            // Shoulder buttons, floating above the body like the real
-            // pad's top edge. L2/R2 sit above L1/R1.
-            let shoulder = |painter: &egui::Painter, rect: Rect, text: &str| {
+            // Shoulder buttons floating above the body's top edge;
+            // bind keys drawn right in the button.
+            let shoulder = |painter: &egui::Painter, rect: Rect, name: &str, key: &str| {
                 painter.rect_filled(rect, CornerRadius::same(6), btn_fill);
                 painter.text(
-                    rect.center(),
+                    Pos2::new(rect.center().x, rect.center().y - 5.0),
                     Align2::CENTER_CENTER,
-                    text,
-                    FontId::proportional(11.0),
+                    name,
+                    FontId::proportional(10.0),
                     Color32::from_rgb(200, 205, 215),
                 );
+                painter.text(
+                    Pos2::new(rect.center().x, rect.center().y + 6.0),
+                    Align2::CENTER_CENTER,
+                    key,
+                    FontId::proportional(8.0),
+                    bind_text,
+                );
             };
-            let l2 = Rect::from_min_max(at(50.0, 8.0), at(115.0, 28.0));
-            let l1 = Rect::from_min_max(at(50.0, 34.0), at(115.0, 58.0));
-            let r2 = Rect::from_min_max(at(355.0, 8.0), at(420.0, 28.0));
-            let r1 = Rect::from_min_max(at(355.0, 34.0), at(420.0, 58.0));
-            shoulder(&painter, l2, "L2");
-            shoulder(&painter, l1, "L1");
-            shoulder(&painter, r2, "R2");
-            shoulder(&painter, r1, "R1");
+            let l2 = Rect::from_min_max(at(50.0, 4.0), at(115.0, 28.0));
+            let l1 = Rect::from_min_max(at(50.0, 32.0), at(115.0, 56.0));
+            let r2 = Rect::from_min_max(at(355.0, 4.0), at(420.0, 28.0));
+            let r1 = Rect::from_min_max(at(355.0, 32.0), at(420.0, 56.0));
+            shoulder(&painter, l2, "L2", &short_bind(PadBindTarget::L2));
+            shoulder(&painter, l1, "L1", &short_bind(PadBindTarget::L1));
+            shoulder(&painter, r2, "R2", &short_bind(PadBindTarget::R2));
+            shoulder(&painter, r1, "R1", &short_bind(PadBindTarget::R1));
             hotspot(ui, l2, PadBindTarget::L2);
             hotspot(ui, l1, PadBindTarget::L1);
             hotspot(ui, r2, PadBindTarget::R2);
             hotspot(ui, r1, PadBindTarget::R1);
 
-            // D-pad: cross of two bars, four directional hotspots.
-            let dpad_c = at(85.0, 125.0);
+            // D-pad: cross of two bars; each arm carries its bind key.
+            let dpad_c = at(105.0, 122.0);
             painter.rect_filled(
-                Rect::from_center_size(dpad_c, Vec2::new(26.0, 82.0)),
-                CornerRadius::same(4),
+                Rect::from_center_size(dpad_c, Vec2::new(28.0, 86.0)),
+                CornerRadius::same(5),
                 btn_fill,
             );
             painter.rect_filled(
-                Rect::from_center_size(dpad_c, Vec2::new(82.0, 26.0)),
-                CornerRadius::same(4),
+                Rect::from_center_size(dpad_c, Vec2::new(86.0, 28.0)),
+                CornerRadius::same(5),
                 btn_fill,
             );
-            let arm = Vec2::new(26.0, 28.0);
-            let arm_h = Vec2::new(28.0, 26.0);
-            hotspot(
-                ui,
-                Rect::from_center_size(dpad_c - Vec2::new(0.0, 27.0), arm),
-                PadBindTarget::Up,
-            );
-            hotspot(
-                ui,
-                Rect::from_center_size(dpad_c + Vec2::new(0.0, 27.0), arm),
-                PadBindTarget::Down,
-            );
-            hotspot(
-                ui,
-                Rect::from_center_size(dpad_c - Vec2::new(27.0, 0.0), arm_h),
-                PadBindTarget::Left,
-            );
-            hotspot(
-                ui,
-                Rect::from_center_size(dpad_c + Vec2::new(27.0, 0.0), arm_h),
-                PadBindTarget::Right,
-            );
+            let dpad_arm = |off: Vec2, target: PadBindTarget| {
+                let rect = Rect::from_center_size(dpad_c + off, Vec2::new(28.0, 28.0));
+                painter.text(
+                    rect.center(),
+                    Align2::CENTER_CENTER,
+                    short_bind(target),
+                    FontId::proportional(7.5),
+                    bind_text,
+                );
+                rect
+            };
+            let up_r = dpad_arm(Vec2::new(0.0, -29.0), PadBindTarget::Up);
+            let down_r = dpad_arm(Vec2::new(0.0, 29.0), PadBindTarget::Down);
+            let left_r = dpad_arm(Vec2::new(-29.0, 0.0), PadBindTarget::Left);
+            let right_r = dpad_arm(Vec2::new(29.0, 0.0), PadBindTarget::Right);
+            hotspot(ui, up_r, PadBindTarget::Up);
+            hotspot(ui, down_r, PadBindTarget::Down);
+            hotspot(ui, left_r, PadBindTarget::Left);
+            hotspot(ui, right_r, PadBindTarget::Right);
 
-            // Face buttons: PS1 symbol colours on dark rounds.
-            let face_c = at(385.0, 125.0);
+            // Face buttons: PS1 symbol colours, bind key under each.
+            let face_c = at(365.0, 122.0);
             let face = |painter: &egui::Painter, c: Pos2, sym: PadBindTarget| {
                 painter.circle_filled(c, 15.0, btn_fill);
                 let s = 6.0;
@@ -1717,11 +1796,18 @@ fn controls_panel(
                     }
                     _ => {}
                 }
+                painter.text(
+                    c + Vec2::new(0.0, 24.0),
+                    Align2::CENTER_CENTER,
+                    short_bind(sym),
+                    FontId::proportional(8.5),
+                    bind_text,
+                );
             };
-            let tri_c = face_c - Vec2::new(0.0, 32.0);
-            let cross_c = face_c + Vec2::new(0.0, 32.0);
-            let sq_c = face_c - Vec2::new(32.0, 0.0);
-            let cir_c = face_c + Vec2::new(32.0, 0.0);
+            let tri_c = face_c - Vec2::new(0.0, 34.0);
+            let cross_c = face_c + Vec2::new(0.0, 34.0);
+            let sq_c = face_c - Vec2::new(34.0, 0.0);
+            let cir_c = face_c + Vec2::new(34.0, 0.0);
             face(&painter, tri_c, PadBindTarget::Triangle);
             face(&painter, cross_c, PadBindTarget::Cross);
             face(&painter, sq_c, PadBindTarget::Square);
@@ -1748,64 +1834,91 @@ fn controls_panel(
                 PadBindTarget::Circle,
             );
 
-            // Select / Start / Analog cluster in the middle.
-            let select_r = Rect::from_min_max(at(190.0, 112.0), at(222.0, 126.0));
-            let start_r = Rect::from_min_max(at(248.0, 112.0), at(280.0, 126.0));
-            painter.rect_filled(select_r, CornerRadius::same(3), btn_fill);
-            painter.rect_filled(start_r, CornerRadius::same(3), btn_fill);
-            painter.text(
-                select_r.center() - Vec2::new(0.0, 12.0),
-                Align2::CENTER_CENTER,
+            // Select / Start / Analog cluster on the bridge, each with
+            // its bind key beneath.
+            let mid_btn = |painter: &egui::Painter, rect: Rect, name: &str, key: &str| {
+                painter.rect_filled(rect, CornerRadius::same(3), btn_fill);
+                painter.text(
+                    Pos2::new(rect.center().x, rect.top() - 6.0),
+                    Align2::CENTER_CENTER,
+                    name,
+                    FontId::proportional(7.5),
+                    theme::MENU_TEXT_DIM,
+                );
+                painter.text(
+                    Pos2::new(rect.center().x, rect.bottom() + 7.0),
+                    Align2::CENTER_CENTER,
+                    key,
+                    FontId::proportional(8.0),
+                    bind_text,
+                );
+            };
+            let select_r = Rect::from_min_max(at(196.0, 96.0), at(228.0, 108.0));
+            let start_r = Rect::from_min_max(at(242.0, 96.0), at(274.0, 108.0));
+            mid_btn(
+                &painter,
+                select_r,
                 "SELECT",
-                FontId::proportional(8.0),
-                theme::MENU_TEXT_DIM,
+                &short_bind(PadBindTarget::Select),
             );
-            painter.text(
-                start_r.center() - Vec2::new(0.0, 12.0),
-                Align2::CENTER_CENTER,
+            mid_btn(
+                &painter,
+                start_r,
                 "START",
-                FontId::proportional(8.0),
-                theme::MENU_TEXT_DIM,
+                &short_bind(PadBindTarget::Start),
             );
             hotspot(ui, select_r, PadBindTarget::Select);
             hotspot(ui, start_r, PadBindTarget::Start);
 
-            let analog_r = Rect::from_min_max(at(219.0, 140.0), at(251.0, 152.0));
+            let analog_r = Rect::from_min_max(at(219.0, 128.0), at(251.0, 140.0));
             painter.rect_filled(analog_r, CornerRadius::same(3), btn_fill);
             painter.text(
                 analog_r.center(),
                 Align2::CENTER_CENTER,
                 "ANALOG",
-                FontId::proportional(7.0),
+                FontId::proportional(6.5),
                 Color32::from_rgb(200, 80, 80),
+            );
+            painter.text(
+                Pos2::new(analog_r.center().x, analog_r.bottom() + 7.0),
+                Align2::CENTER_CENTER,
+                short_bind(PadBindTarget::Analog),
+                FontId::proportional(8.0),
+                bind_text,
             );
             hotspot(ui, analog_r, PadBindTarget::Analog);
 
-            // Analog sticks: the circle itself is the stick click
-            // (L3/R3); the four chips around it are the
-            // keyboard-emulated stick directions.
+            // Analog sticks on the grips: the circle is the stick
+            // click (L3/R3, bind key inside), the four chips around it
+            // are the keyboard-emulated stick directions.
             let stick = |ui: &mut egui::Ui,
                          painter: &egui::Painter,
                          hotspot: &mut dyn FnMut(&mut egui::Ui, Rect, PadBindTarget),
                          c: Pos2,
                          click: PadBindTarget,
                          dirs: [PadBindTarget; 4]| {
-                painter.circle_filled(c, 20.0, btn_fill);
-                painter.circle_filled(c, 12.0, body_fill);
+                painter.circle_filled(c, 21.0, btn_fill);
+                painter.circle_filled(c, 13.0, body_fill);
                 painter.text(
-                    c,
+                    c - Vec2::new(0.0, 5.0),
                     Align2::CENTER_CENTER,
                     match click {
                         PadBindTarget::L3 => "L3",
                         _ => "R3",
                     },
-                    FontId::proportional(9.0),
+                    FontId::proportional(8.5),
                     theme::MENU_TEXT_DIM,
                 );
-                hotspot(ui, Rect::from_center_size(c, Vec2::splat(26.0)), click);
-                // Direction chips: up, down, left, right.
-                let chip = 13.0;
-                let offs = 30.0;
+                painter.text(
+                    c + Vec2::new(0.0, 5.0),
+                    Align2::CENTER_CENTER,
+                    short_bind(click),
+                    FontId::proportional(7.0),
+                    bind_text,
+                );
+                hotspot(ui, Rect::from_center_size(c, Vec2::splat(28.0)), click);
+                let chip = 14.0;
+                let offs = 32.0;
                 let dirs_off = [
                     Vec2::new(0.0, -offs),
                     Vec2::new(0.0, offs),
@@ -1830,7 +1943,7 @@ fn controls_panel(
                 ui,
                 &painter,
                 &mut hotspot,
-                at(175.0, 200.0),
+                at(178.0, 215.0),
                 PadBindTarget::L3,
                 [
                     PadBindTarget::LStickUp,
@@ -1843,7 +1956,7 @@ fn controls_panel(
                 ui,
                 &painter,
                 &mut hotspot,
-                at(295.0, 200.0),
+                at(292.0, 215.0),
                 PadBindTarget::R3,
                 [
                     PadBindTarget::RStickUp,
@@ -1852,49 +1965,106 @@ fn controls_panel(
                     PadBindTarget::RStickRight,
                 ],
             );
-            // Body outline last so it frames everything cleanly.
-            painter.rect_stroke(
-                Rect::from_min_max(at(30.0, 70.0), at(440.0, 185.0)),
-                CornerRadius::same(26),
-                body_edge,
-                egui::StrokeKind::Middle,
-            );
 
-            ui.add_space(6.0);
+            ui.add_space(2.0);
             ui.separator();
 
-            // Complete clickable list -- same capture flow as the
-            // drawing, guaranteed to cover every target.
+            // Grouped clickable list -- same capture flow as the
+            // drawing, guaranteed to cover every target, with full
+            // (unelided) key names.
+            const GROUPS: [(&str, &[PadBindTarget]); 6] = [
+                (
+                    "D-Pad",
+                    &[
+                        PadBindTarget::Up,
+                        PadBindTarget::Down,
+                        PadBindTarget::Left,
+                        PadBindTarget::Right,
+                    ],
+                ),
+                (
+                    "Face buttons",
+                    &[
+                        PadBindTarget::Cross,
+                        PadBindTarget::Circle,
+                        PadBindTarget::Square,
+                        PadBindTarget::Triangle,
+                    ],
+                ),
+                (
+                    "Shoulders",
+                    &[
+                        PadBindTarget::L1,
+                        PadBindTarget::L2,
+                        PadBindTarget::R1,
+                        PadBindTarget::R2,
+                    ],
+                ),
+                (
+                    "Start / Select",
+                    &[PadBindTarget::Start, PadBindTarget::Select],
+                ),
+                (
+                    "Left stick",
+                    &[
+                        PadBindTarget::L3,
+                        PadBindTarget::LStickUp,
+                        PadBindTarget::LStickDown,
+                        PadBindTarget::LStickLeft,
+                        PadBindTarget::LStickRight,
+                    ],
+                ),
+                (
+                    "Right stick + DualShock",
+                    &[
+                        PadBindTarget::R3,
+                        PadBindTarget::RStickUp,
+                        PadBindTarget::RStickDown,
+                        PadBindTarget::RStickLeft,
+                        PadBindTarget::RStickRight,
+                        PadBindTarget::Analog,
+                    ],
+                ),
+            ];
             egui::ScrollArea::vertical()
                 .max_height(150.0)
                 .show(ui, |ui| {
-                    egui::Grid::new("controls-bind-grid")
-                        .num_columns(2)
-                        .striped(true)
-                        .min_col_width(150.0)
-                        .show(ui, |ui| {
-                            for target in PadBindTarget::ALL {
-                                ui.label(egui::RichText::new(target.label()).size(12.0));
-                                let armed = *capture == Some(target);
-                                let text = if armed {
-                                    "press a key...".to_string()
-                                } else {
-                                    bind_of(target)
-                                };
-                                let btn = egui::Button::new(
-                                    egui::RichText::new(text).size(12.0).color(if armed {
-                                        theme::MENU_ACCENT
+                    for (group, targets) in GROUPS {
+                        ui.add_space(3.0);
+                        ui.label(
+                            egui::RichText::new(group)
+                                .color(theme::MENU_ACCENT)
+                                .size(11.0)
+                                .strong(),
+                        );
+                        egui::Grid::new(group)
+                            .num_columns(2)
+                            .striped(true)
+                            .min_col_width(150.0)
+                            .show(ui, |ui| {
+                                for &target in targets {
+                                    ui.label(egui::RichText::new(target.label()).size(12.0));
+                                    let armed = *capture == Some(target);
+                                    let text = if armed {
+                                        "press a key...".to_string()
                                     } else {
-                                        Color32::from_rgb(220, 224, 232)
-                                    }),
-                                )
-                                .min_size(Vec2::new(120.0, 18.0));
-                                if ui.add(btn).clicked() {
-                                    *capture = Some(target);
+                                        bind_of(target)
+                                    };
+                                    let btn = egui::Button::new(
+                                        egui::RichText::new(text).size(12.0).color(if armed {
+                                            theme::MENU_ACCENT
+                                        } else {
+                                            Color32::from_rgb(220, 224, 232)
+                                        }),
+                                    )
+                                    .min_size(Vec2::new(120.0, 18.0));
+                                    if ui.add(btn).clicked() {
+                                        *capture = Some(target);
+                                    }
+                                    ui.end_row();
                                 }
-                                ui.end_row();
-                            }
-                        });
+                            });
+                    }
                 });
 
             ui.add_space(6.0);
@@ -1915,7 +2085,6 @@ fn controls_panel(
         });
     *open = still_open;
 }
-
 /// Paint a save's thumbnail at `size`, loading and caching the
 /// texture on first use. Draws a plain placeholder box when `path` is
 /// `None` (no capture for this save) or fails to decode.

--- a/emu/crates/frontend/src/ui/menu.rs
+++ b/emu/crates/frontend/src/ui/menu.rs
@@ -1520,6 +1520,12 @@ fn save_states_panel(
 /// doubles as an in-app rollover/ghosting tester: hold three keys and
 /// see exactly which ones the keyboard actually delivered.
 ///
+/// The silhouette is drawn from the PS1 pad's real construction: two
+/// circular pods carrying the d-pad and face cluster, a narrower
+/// bridge between them, and capsule grips flaring down-outward.
+/// Everything routes through one scale constant so the whole drawing
+/// (and its text) can be resized in one place.
+///
 /// Rebinds don't go through [`MenuAction`]: clicking a hotspot arms
 /// `capture`, and the shell's keyboard handler consumes the next
 /// physical key into the binding (Escape cancels). Reset does dispatch
@@ -1535,18 +1541,34 @@ fn controls_panel(
 ) {
     use egui::{Color32, CornerRadius, Sense, Stroke};
 
-    const CANVAS: Vec2 = Vec2::new(470.0, 300.0);
+    /// One knob for the whole drawing: positions, sizes, and font
+    /// sizes below are in a 470x300 design space multiplied by this.
+    const S: f32 = 1.35;
+    const CANVAS: Vec2 = Vec2::new(470.0 * S, 300.0 * S);
+
     let bind_of =
         |t: PadBindTarget| -> String { labels.get(&t).cloned().unwrap_or_else(|| "-".to_string()) };
-    // Space on the drawing is tight; long names ("NumpadSubtract")
-    // elide there but stay complete in the list and hover text.
+    // Space on the drawing is tight: well-known names compact to
+    // glyphs/abbreviations, anything still too long elides. The list
+    // and hover text always carry the full name.
     let short_bind = |t: PadBindTarget| -> String {
         let full = bind_of(t);
-        if full.chars().count() > 7 {
-            let head: String = full.chars().take(6).collect();
+        // ASCII stand-ins for the arrows: the menu font has no
+        // U+2190..2193 glyphs (they render as .notdef boxes).
+        let compact = match full.as_str() {
+            "ArrowUp" => "^".to_string(),
+            "ArrowDown" => "v".to_string(),
+            "ArrowLeft" => "<".to_string(),
+            "ArrowRight" => ">".to_string(),
+            "Backspace" => "Bksp".to_string(),
+            "Space" => "Spc".to_string(),
+            other => other.replace("Numpad", "Num"),
+        };
+        if compact.chars().count() > 7 {
+            let head: String = compact.chars().take(6).collect();
             format!("{head}\u{2026}")
         } else {
-            full
+            compact
         }
     };
 
@@ -1564,6 +1586,10 @@ fn controls_panel(
         .open(&mut still_open)
         .collapsible(false)
         .resizable(false)
+        // Foreground: the Menu overlay paints on a mid-layer painter
+        // above ordinary windows, so without this the category list
+        // draws straight over the panel when both are up.
+        .order(egui::Order::Foreground)
         .anchor(Align2::CENTER_CENTER, Vec2::ZERO)
         .show(ctx, |ui| {
             // Capture banner / hint line above the drawing.
@@ -1576,7 +1602,8 @@ fn controls_panel(
                             target.label()
                         ))
                         .color(theme::MENU_ACCENT)
-                        .strong(),
+                        .strong()
+                        .size(14.0),
                     );
                 }
                 None => {
@@ -1586,7 +1613,7 @@ fn controls_panel(
                              immediately and are saved. Held keys light up green.",
                         )
                         .color(theme::MENU_TEXT_DIM)
-                        .size(12.0),
+                        .size(13.0),
                     );
                 }
             }
@@ -1594,13 +1621,15 @@ fn controls_panel(
 
             let (resp, painter) = ui.allocate_painter(CANVAS, Sense::hover());
             let origin = resp.rect.min;
-            let at = |x: f32, y: f32| Pos2::new(origin.x + x, origin.y + y);
+            let at = |x: f32, y: f32| Pos2::new(origin.x + x * S, origin.y + y * S);
+            let sz = |w: f32, h: f32| Vec2::new(w * S, h * S);
+            let sc = |v: f32| v * S;
             // Pulse for the armed hotspot: 2 Hz sine on the ui clock.
             let pulse = ((ui.input(|i| i.time) * std::f64::consts::TAU).sin() * 0.5 + 0.5) as f32;
 
-            let body_fill = Color32::from_rgb(52, 56, 64);
-            let body_hilight = Color32::from_rgb(64, 69, 79);
-            let btn_fill = Color32::from_rgb(34, 37, 43);
+            let body_fill = Color32::from_rgb(58, 62, 71);
+            let body_shade = Color32::from_rgb(48, 52, 60);
+            let btn_fill = Color32::from_rgb(30, 33, 39);
             let held_fill = Color32::from_rgba_unmultiplied(70, 190, 110, 70);
             let held_ring = Stroke::new(2.0, Color32::from_rgb(80, 210, 120));
             let bind_text = Color32::from_rgb(150, 200, 235);
@@ -1651,65 +1680,68 @@ fn controls_panel(
                 }
             };
 
-            // Controller body: two rounded wings bridged in the middle,
-            // grips flaring down-outward -- the PS1 silhouette.
-            let left_wing = Rect::from_min_max(at(22.0, 62.0), at(195.0, 185.0));
-            let right_wing = Rect::from_min_max(at(275.0, 62.0), at(448.0, 185.0));
-            let bridge = Rect::from_min_max(at(150.0, 72.0), at(320.0, 172.0));
-            painter.rect_filled(left_wing, CornerRadius::same(34), body_fill);
-            painter.rect_filled(right_wing, CornerRadius::same(34), body_fill);
-            painter.rect_filled(bridge, CornerRadius::same(16), body_fill);
-            // Grips: angled quads continuing the wings downward.
+            // Capsule polygon spanning `a`..`b` with radius `r` --
+            // used for the grips. Convex by construction.
+            let capsule = |a: Pos2, b: Pos2, r: f32| -> Vec<Pos2> {
+                let theta = (b - a).angle();
+                let mut pts = Vec::with_capacity(26);
+                for i in 0..=12 {
+                    let phi = theta - std::f32::consts::FRAC_PI_2
+                        + std::f32::consts::PI * (i as f32 / 12.0);
+                    pts.push(b + r * Vec2::angled(phi));
+                }
+                for i in 0..=12 {
+                    let phi = theta
+                        + std::f32::consts::FRAC_PI_2
+                        + std::f32::consts::PI * (i as f32 / 12.0);
+                    pts.push(a + r * Vec2::angled(phi));
+                }
+                pts
+            };
+
+            // --- Body: grips first (they sit behind), then the two
+            // circular pods, then the narrower bridge that joins them.
             painter.add(egui::Shape::convex_polygon(
-                vec![
-                    at(40.0, 150.0),
-                    at(120.0, 170.0),
-                    at(105.0, 262.0),
-                    at(38.0, 240.0),
-                ],
-                body_fill,
+                capsule(at(96.0, 160.0), at(62.0, 272.0), sc(31.0)),
+                body_shade,
                 Stroke::NONE,
             ));
             painter.add(egui::Shape::convex_polygon(
-                vec![
-                    at(350.0, 170.0),
-                    at(430.0, 150.0),
-                    at(432.0, 240.0),
-                    at(365.0, 262.0),
-                ],
-                body_fill,
+                capsule(at(374.0, 160.0), at(408.0, 272.0), sc(31.0)),
+                body_shade,
                 Stroke::NONE,
             ));
-            // Subtle top sheen so the slab reads as a molded shell.
+            painter.circle_filled(at(105.0, 128.0), sc(66.0), body_fill);
+            painter.circle_filled(at(365.0, 128.0), sc(66.0), body_fill);
             painter.rect_filled(
-                Rect::from_min_max(at(34.0, 68.0), at(436.0, 82.0)),
-                CornerRadius::same(7),
-                body_hilight,
+                Rect::from_min_max(at(105.0, 84.0), at(365.0, 172.0)),
+                CornerRadius::same(10),
+                body_fill,
             );
 
-            // Shoulder buttons floating above the body's top edge;
+            // Shoulder buttons floating above the pods' top edge;
             // bind keys drawn right in the button.
             let shoulder = |painter: &egui::Painter, rect: Rect, name: &str, key: &str| {
                 painter.rect_filled(rect, CornerRadius::same(6), btn_fill);
                 painter.text(
-                    Pos2::new(rect.center().x, rect.center().y - 5.0),
+                    Pos2::new(rect.center().x, rect.center().y - sc(5.0)),
                     Align2::CENTER_CENTER,
                     name,
-                    FontId::proportional(10.0),
+                    FontId::proportional(sc(9.0)),
                     Color32::from_rgb(200, 205, 215),
                 );
                 painter.text(
-                    Pos2::new(rect.center().x, rect.center().y + 6.0),
+                    Pos2::new(rect.center().x, rect.center().y + sc(6.0)),
                     Align2::CENTER_CENTER,
                     key,
-                    FontId::proportional(8.0),
+                    FontId::proportional(sc(7.5)),
                     bind_text,
                 );
             };
-            let l2 = Rect::from_min_max(at(50.0, 4.0), at(115.0, 28.0));
-            let l1 = Rect::from_min_max(at(50.0, 32.0), at(115.0, 56.0));
-            let r2 = Rect::from_min_max(at(355.0, 4.0), at(420.0, 28.0));
-            let r1 = Rect::from_min_max(at(355.0, 32.0), at(420.0, 56.0));
+            let l2 = Rect::from_min_max(at(56.0, 8.0), at(120.0, 32.0));
+            let l1 = Rect::from_min_max(at(56.0, 38.0), at(120.0, 62.0));
+            let r2 = Rect::from_min_max(at(350.0, 8.0), at(414.0, 32.0));
+            let r1 = Rect::from_min_max(at(350.0, 38.0), at(414.0, 62.0));
             shoulder(&painter, l2, "L2", &short_bind(PadBindTarget::L2));
             shoulder(&painter, l1, "L1", &short_bind(PadBindTarget::L1));
             shoulder(&painter, r2, "R2", &short_bind(PadBindTarget::R2));
@@ -1719,43 +1751,45 @@ fn controls_panel(
             hotspot(ui, r2, PadBindTarget::R2);
             hotspot(ui, r1, PadBindTarget::R1);
 
-            // D-pad: cross of two bars; each arm carries its bind key.
-            let dpad_c = at(105.0, 122.0);
+            // D-pad on the left pod: cross of two bars, each arm
+            // carrying its bind key.
+            let dpad_c = at(105.0, 128.0);
             painter.rect_filled(
-                Rect::from_center_size(dpad_c, Vec2::new(28.0, 86.0)),
+                Rect::from_center_size(dpad_c, sz(30.0, 92.0)),
                 CornerRadius::same(5),
                 btn_fill,
             );
             painter.rect_filled(
-                Rect::from_center_size(dpad_c, Vec2::new(86.0, 28.0)),
+                Rect::from_center_size(dpad_c, sz(92.0, 30.0)),
                 CornerRadius::same(5),
                 btn_fill,
             );
             let dpad_arm = |off: Vec2, target: PadBindTarget| {
-                let rect = Rect::from_center_size(dpad_c + off, Vec2::new(28.0, 28.0));
+                let rect = Rect::from_center_size(dpad_c + off * S, sz(30.0, 30.0));
                 painter.text(
                     rect.center(),
                     Align2::CENTER_CENTER,
                     short_bind(target),
-                    FontId::proportional(7.5),
+                    FontId::proportional(sc(7.0)),
                     bind_text,
                 );
                 rect
             };
-            let up_r = dpad_arm(Vec2::new(0.0, -29.0), PadBindTarget::Up);
-            let down_r = dpad_arm(Vec2::new(0.0, 29.0), PadBindTarget::Down);
-            let left_r = dpad_arm(Vec2::new(-29.0, 0.0), PadBindTarget::Left);
-            let right_r = dpad_arm(Vec2::new(29.0, 0.0), PadBindTarget::Right);
+            let up_r = dpad_arm(Vec2::new(0.0, -31.0), PadBindTarget::Up);
+            let down_r = dpad_arm(Vec2::new(0.0, 31.0), PadBindTarget::Down);
+            let left_r = dpad_arm(Vec2::new(-31.0, 0.0), PadBindTarget::Left);
+            let right_r = dpad_arm(Vec2::new(31.0, 0.0), PadBindTarget::Right);
             hotspot(ui, up_r, PadBindTarget::Up);
             hotspot(ui, down_r, PadBindTarget::Down);
             hotspot(ui, left_r, PadBindTarget::Left);
             hotspot(ui, right_r, PadBindTarget::Right);
 
-            // Face buttons: PS1 symbol colours, bind key under each.
-            let face_c = at(365.0, 122.0);
+            // Face buttons on the right pod: PS1 symbol colours, bind
+            // key under each.
+            let face_c = at(365.0, 128.0);
             let face = |painter: &egui::Painter, c: Pos2, sym: PadBindTarget| {
-                painter.circle_filled(c, 15.0, btn_fill);
-                let s = 6.0;
+                painter.circle_filled(c, sc(16.0), btn_fill);
+                let s = sc(6.5);
                 match sym {
                     PadBindTarget::Triangle => {
                         let col = Color32::from_rgb(64, 190, 130);
@@ -1797,22 +1831,22 @@ fn controls_panel(
                     _ => {}
                 }
                 painter.text(
-                    c + Vec2::new(0.0, 24.0),
+                    c + Vec2::new(0.0, sc(25.0)),
                     Align2::CENTER_CENTER,
                     short_bind(sym),
-                    FontId::proportional(8.5),
+                    FontId::proportional(sc(8.0)),
                     bind_text,
                 );
             };
-            let tri_c = face_c - Vec2::new(0.0, 34.0);
-            let cross_c = face_c + Vec2::new(0.0, 34.0);
-            let sq_c = face_c - Vec2::new(34.0, 0.0);
-            let cir_c = face_c + Vec2::new(34.0, 0.0);
+            let tri_c = face_c - Vec2::new(0.0, sc(36.0));
+            let cross_c = face_c + Vec2::new(0.0, sc(36.0));
+            let sq_c = face_c - Vec2::new(sc(36.0), 0.0);
+            let cir_c = face_c + Vec2::new(sc(36.0), 0.0);
             face(&painter, tri_c, PadBindTarget::Triangle);
             face(&painter, cross_c, PadBindTarget::Cross);
             face(&painter, sq_c, PadBindTarget::Square);
             face(&painter, cir_c, PadBindTarget::Circle);
-            let face_hit = Vec2::splat(30.0);
+            let face_hit = Vec2::splat(sc(32.0));
             hotspot(
                 ui,
                 Rect::from_center_size(tri_c, face_hit),
@@ -1839,22 +1873,22 @@ fn controls_panel(
             let mid_btn = |painter: &egui::Painter, rect: Rect, name: &str, key: &str| {
                 painter.rect_filled(rect, CornerRadius::same(3), btn_fill);
                 painter.text(
-                    Pos2::new(rect.center().x, rect.top() - 6.0),
+                    Pos2::new(rect.center().x, rect.top() - sc(6.0)),
                     Align2::CENTER_CENTER,
                     name,
-                    FontId::proportional(7.5),
+                    FontId::proportional(sc(7.0)),
                     theme::MENU_TEXT_DIM,
                 );
                 painter.text(
-                    Pos2::new(rect.center().x, rect.bottom() + 7.0),
+                    Pos2::new(rect.center().x, rect.bottom() + sc(7.0)),
                     Align2::CENTER_CENTER,
                     key,
-                    FontId::proportional(8.0),
+                    FontId::proportional(sc(7.5)),
                     bind_text,
                 );
             };
-            let select_r = Rect::from_min_max(at(196.0, 96.0), at(228.0, 108.0));
-            let start_r = Rect::from_min_max(at(242.0, 96.0), at(274.0, 108.0));
+            let select_r = Rect::from_min_max(at(194.0, 100.0), at(228.0, 113.0));
+            let start_r = Rect::from_min_max(at(242.0, 100.0), at(276.0, 113.0));
             mid_btn(
                 &painter,
                 select_r,
@@ -1870,62 +1904,63 @@ fn controls_panel(
             hotspot(ui, select_r, PadBindTarget::Select);
             hotspot(ui, start_r, PadBindTarget::Start);
 
-            let analog_r = Rect::from_min_max(at(219.0, 128.0), at(251.0, 140.0));
+            let analog_r = Rect::from_min_max(at(217.0, 136.0), at(253.0, 149.0));
             painter.rect_filled(analog_r, CornerRadius::same(3), btn_fill);
             painter.text(
                 analog_r.center(),
                 Align2::CENTER_CENTER,
                 "ANALOG",
-                FontId::proportional(6.5),
+                FontId::proportional(sc(6.0)),
                 Color32::from_rgb(200, 80, 80),
             );
             painter.text(
-                Pos2::new(analog_r.center().x, analog_r.bottom() + 7.0),
+                Pos2::new(analog_r.center().x, analog_r.bottom() + sc(7.0)),
                 Align2::CENTER_CENTER,
                 short_bind(PadBindTarget::Analog),
-                FontId::proportional(8.0),
+                FontId::proportional(sc(7.5)),
                 bind_text,
             );
             hotspot(ui, analog_r, PadBindTarget::Analog);
 
-            // Analog sticks on the grips: the circle is the stick
-            // click (L3/R3, bind key inside), the four chips around it
-            // are the keyboard-emulated stick directions.
+            // Analog sticks between the grips, DualShock-style: the
+            // circle is the stick click (L3/R3, bind key inside), the
+            // four chips around it are the keyboard-emulated stick
+            // directions.
             let stick = |ui: &mut egui::Ui,
                          painter: &egui::Painter,
                          hotspot: &mut dyn FnMut(&mut egui::Ui, Rect, PadBindTarget),
                          c: Pos2,
                          click: PadBindTarget,
                          dirs: [PadBindTarget; 4]| {
-                painter.circle_filled(c, 21.0, btn_fill);
-                painter.circle_filled(c, 13.0, body_fill);
+                painter.circle_filled(c, sc(22.0), btn_fill);
+                painter.circle_filled(c, sc(14.0), body_shade);
                 painter.text(
-                    c - Vec2::new(0.0, 5.0),
+                    c - Vec2::new(0.0, sc(5.0)),
                     Align2::CENTER_CENTER,
                     match click {
                         PadBindTarget::L3 => "L3",
                         _ => "R3",
                     },
-                    FontId::proportional(8.5),
-                    theme::MENU_TEXT_DIM,
+                    FontId::proportional(sc(8.0)),
+                    Color32::from_rgb(200, 205, 215),
                 );
                 painter.text(
-                    c + Vec2::new(0.0, 5.0),
+                    c + Vec2::new(0.0, sc(5.0)),
                     Align2::CENTER_CENTER,
                     short_bind(click),
-                    FontId::proportional(7.0),
+                    FontId::proportional(sc(6.5)),
                     bind_text,
                 );
-                hotspot(ui, Rect::from_center_size(c, Vec2::splat(28.0)), click);
-                let chip = 14.0;
-                let offs = 32.0;
+                hotspot(ui, Rect::from_center_size(c, Vec2::splat(sc(30.0))), click);
+                let chip = sc(15.0);
+                let offs = sc(34.0);
                 let dirs_off = [
                     Vec2::new(0.0, -offs),
                     Vec2::new(0.0, offs),
                     Vec2::new(-offs, 0.0),
                     Vec2::new(offs, 0.0),
                 ];
-                let glyphs = ["\u{2191}", "\u{2193}", "\u{2190}", "\u{2192}"];
+                let glyphs = ["^", "v", "<", ">"];
                 for ((target, off), glyph) in dirs.iter().zip(dirs_off).zip(glyphs) {
                     let r = Rect::from_center_size(c + off, Vec2::splat(chip));
                     painter.rect_filled(r, CornerRadius::same(3), btn_fill);
@@ -1933,7 +1968,7 @@ fn controls_panel(
                         r.center(),
                         Align2::CENTER_CENTER,
                         glyph,
-                        FontId::proportional(9.0),
+                        FontId::proportional(sc(9.0)),
                         theme::MENU_TEXT_DIM,
                     );
                     hotspot(ui, r, *target);
@@ -1943,7 +1978,7 @@ fn controls_panel(
                 ui,
                 &painter,
                 &mut hotspot,
-                at(178.0, 215.0),
+                at(184.0, 218.0),
                 PadBindTarget::L3,
                 [
                     PadBindTarget::LStickUp,
@@ -1956,7 +1991,7 @@ fn controls_panel(
                 ui,
                 &painter,
                 &mut hotspot,
-                at(292.0, 215.0),
+                at(286.0, 218.0),
                 PadBindTarget::R3,
                 [
                     PadBindTarget::RStickUp,
@@ -2027,23 +2062,23 @@ fn controls_panel(
                 ),
             ];
             egui::ScrollArea::vertical()
-                .max_height(150.0)
+                .max_height(170.0)
                 .show(ui, |ui| {
                     for (group, targets) in GROUPS {
                         ui.add_space(3.0);
                         ui.label(
                             egui::RichText::new(group)
                                 .color(theme::MENU_ACCENT)
-                                .size(11.0)
+                                .size(12.0)
                                 .strong(),
                         );
                         egui::Grid::new(group)
                             .num_columns(2)
                             .striped(true)
-                            .min_col_width(150.0)
+                            .min_col_width(190.0)
                             .show(ui, |ui| {
                                 for &target in targets {
-                                    ui.label(egui::RichText::new(target.label()).size(12.0));
+                                    ui.label(egui::RichText::new(target.label()).size(13.0));
                                     let armed = *capture == Some(target);
                                     let text = if armed {
                                         "press a key...".to_string()
@@ -2051,13 +2086,13 @@ fn controls_panel(
                                         bind_of(target)
                                     };
                                     let btn = egui::Button::new(
-                                        egui::RichText::new(text).size(12.0).color(if armed {
+                                        egui::RichText::new(text).size(13.0).color(if armed {
                                             theme::MENU_ACCENT
                                         } else {
                                             Color32::from_rgb(220, 224, 232)
                                         }),
                                     )
-                                    .min_size(Vec2::new(120.0, 18.0));
+                                    .min_size(Vec2::new(150.0, 20.0));
                                     if ui.add(btn).clicked() {
                                         *capture = Some(target);
                                     }

--- a/emu/crates/frontend/src/ui/menu.rs
+++ b/emu/crates/frontend/src/ui/menu.rs
@@ -66,6 +66,13 @@ pub enum MenuAction {
     /// load-with-confirmation) -- driven by the always-visible toolbar
     /// icon as well as the System category's "Save states" row.
     OpenSaveStates,
+    /// Open the controls panel (clickable PS1 controller drawing,
+    /// press-a-key rebinding, reset to defaults) -- driven by the
+    /// always-visible toolbar icon as well as the System category's
+    /// "Controls" row.
+    OpenControls,
+    /// Restore every port-1 binding to the built-in defaults.
+    ResetControls,
     /// Pin the given slot as the save history's "top" -- the target
     /// [`MenuAction::LoadState`] via F7/quick-load resolves to --
     /// without touching slot numbering or any other save's position.
@@ -103,6 +110,103 @@ pub enum MenuAction {
     Noop,
     /// Quit the application.
     Quit,
+}
+
+/// Every rebindable port-1 input the controls panel exposes -- the
+/// full PS1 pad (d-pad, face, shoulders, Start/Select, stick clicks,
+/// the DualShock Analog toggle) plus the keyboard-emulated analog
+/// stick directions. The app layer maps each target onto its
+/// `psoxide_settings` binding field; the Menu module stays decoupled
+/// from the settings crate's types, same as [`LibraryItem`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PadBindTarget {
+    Up,
+    Down,
+    Left,
+    Right,
+    Cross,
+    Circle,
+    Square,
+    Triangle,
+    L1,
+    L2,
+    R1,
+    R2,
+    Start,
+    Select,
+    L3,
+    R3,
+    Analog,
+    LStickUp,
+    LStickDown,
+    LStickLeft,
+    LStickRight,
+    RStickUp,
+    RStickDown,
+    RStickLeft,
+    RStickRight,
+}
+
+impl PadBindTarget {
+    /// Every target, in the order the panel's fallback list renders.
+    pub const ALL: [PadBindTarget; 25] = [
+        PadBindTarget::Up,
+        PadBindTarget::Down,
+        PadBindTarget::Left,
+        PadBindTarget::Right,
+        PadBindTarget::Cross,
+        PadBindTarget::Circle,
+        PadBindTarget::Square,
+        PadBindTarget::Triangle,
+        PadBindTarget::L1,
+        PadBindTarget::L2,
+        PadBindTarget::R1,
+        PadBindTarget::R2,
+        PadBindTarget::Start,
+        PadBindTarget::Select,
+        PadBindTarget::L3,
+        PadBindTarget::R3,
+        PadBindTarget::Analog,
+        PadBindTarget::LStickUp,
+        PadBindTarget::LStickDown,
+        PadBindTarget::LStickLeft,
+        PadBindTarget::LStickRight,
+        PadBindTarget::RStickUp,
+        PadBindTarget::RStickDown,
+        PadBindTarget::RStickLeft,
+        PadBindTarget::RStickRight,
+    ];
+
+    /// Short display name drawn on/next to the hotspot.
+    pub fn label(self) -> &'static str {
+        match self {
+            PadBindTarget::Up => "D-Pad Up",
+            PadBindTarget::Down => "D-Pad Down",
+            PadBindTarget::Left => "D-Pad Left",
+            PadBindTarget::Right => "D-Pad Right",
+            PadBindTarget::Cross => "Cross",
+            PadBindTarget::Circle => "Circle",
+            PadBindTarget::Square => "Square",
+            PadBindTarget::Triangle => "Triangle",
+            PadBindTarget::L1 => "L1",
+            PadBindTarget::L2 => "L2",
+            PadBindTarget::R1 => "R1",
+            PadBindTarget::R2 => "R2",
+            PadBindTarget::Start => "Start",
+            PadBindTarget::Select => "Select",
+            PadBindTarget::L3 => "L3",
+            PadBindTarget::R3 => "R3",
+            PadBindTarget::Analog => "Analog",
+            PadBindTarget::LStickUp => "L-Stick Up",
+            PadBindTarget::LStickDown => "L-Stick Down",
+            PadBindTarget::LStickLeft => "L-Stick Left",
+            PadBindTarget::LStickRight => "L-Stick Right",
+            PadBindTarget::RStickUp => "R-Stick Up",
+            PadBindTarget::RStickDown => "R-Stick Down",
+            PadBindTarget::RStickLeft => "R-Stick Left",
+            PadBindTarget::RStickRight => "R-Stick Right",
+        }
+    }
 }
 
 /// Per-frame input snapshot the shell assembles from keyboard events.
@@ -195,6 +299,18 @@ pub struct MenuState {
     /// written (saves are a history, not overwritten slots), so a
     /// path is a stable cache key for the process's lifetime.
     save_thumb_cache: HashMap<PathBuf, egui::TextureHandle>,
+    /// Whether the controls panel (PS1 controller drawing + rebinds)
+    /// is showing. Like `save_states_open`, reachable from the
+    /// always-visible toolbar icon independent of the Menu overlay.
+    controls_open: bool,
+    /// The target currently waiting for a key press, if the user
+    /// clicked a hotspot. The shell's keyboard handler consumes the
+    /// next physical key into this instead of routing it anywhere
+    /// else (Escape cancels).
+    controls_capture: Option<PadBindTarget>,
+    /// Current binding label per target, synced from the app layer via
+    /// [`MenuState::sync_controls`] whenever a binding changes.
+    controls_labels: HashMap<PadBindTarget, String>,
     pending_pointer_action: Option<MenuAction>,
     categories: Vec<Category>,
 }
@@ -319,6 +435,9 @@ impl MenuState {
             save_rows: Vec::new(),
             pending_load_confirm: None,
             save_thumb_cache: HashMap::new(),
+            controls_open: false,
+            controls_capture: None,
+            controls_labels: HashMap::new(),
             pending_pointer_action: None,
             categories,
         }
@@ -421,6 +540,32 @@ impl MenuState {
     /// toolbar icon and the System category's "Save states" row.
     pub fn open_save_states(&mut self) {
         self.save_states_open = true;
+    }
+
+    /// Open the controls panel. Driven by the always-visible toolbar
+    /// icon and the System category's "Controls" row.
+    pub fn open_controls(&mut self) {
+        self.controls_open = true;
+    }
+
+    /// Replace the per-target binding labels the controls panel shows.
+    /// The app layer calls this at startup and after every rebind /
+    /// reset, so the panel always reflects what the settings actually
+    /// persist.
+    pub fn sync_controls(&mut self, labels: impl IntoIterator<Item = (PadBindTarget, String)>) {
+        self.controls_labels = labels.into_iter().collect();
+    }
+
+    /// The target currently waiting for a key press, if any. The
+    /// shell's keyboard handler checks this every key event: while a
+    /// capture is armed, keys feed the rebind instead of the game.
+    pub fn controls_capture(&self) -> Option<PadBindTarget> {
+        self.controls_capture
+    }
+
+    /// Disarm the pending capture (key consumed or Escape pressed).
+    pub fn clear_controls_capture(&mut self) {
+        self.controls_capture = None;
     }
 
     /// Store the menu-backdrop opacity (percent) and reflect it in the
@@ -594,6 +739,21 @@ impl MenuState {
                 &mut self.save_thumb_cache,
                 &mut self.pending_pointer_action,
             );
+        }
+        // The controls panel is likewise toolbar-reachable and lives
+        // outside the appear-gate so rebinding works mid-game. Closing
+        // the panel disarms any pending key capture with it.
+        if self.controls_open {
+            controls_panel(
+                ctx,
+                &mut self.controls_open,
+                &self.controls_labels,
+                &mut self.controls_capture,
+                &mut self.pending_pointer_action,
+            );
+            if !self.controls_open {
+                self.controls_capture = None;
+            }
         }
         // The About card belongs to the open menu; drop it the moment the menu
         // is dismissed so it can't linger through the close dissolve.
@@ -1326,6 +1486,436 @@ fn save_states_panel(
     }
 }
 
+/// The controls panel: a painter-drawn PS1 controller whose parts are
+/// clickable rebind hotspots, a full clickable list of every target
+/// below it (the drawing is the fast path, the list is the complete
+/// one), a live capture banner, and a reset-to-defaults button.
+///
+/// Rebinds don't go through [`MenuAction`]: clicking a hotspot arms
+/// `capture`, and the shell's keyboard handler consumes the next
+/// physical key into the binding (Escape cancels). Reset does dispatch
+/// via `pending_pointer_action`, like every other pointer-driven
+/// action.
+fn controls_panel(
+    ctx: &egui::Context,
+    open: &mut bool,
+    labels: &HashMap<PadBindTarget, String>,
+    capture: &mut Option<PadBindTarget>,
+    pending_pointer_action: &mut Option<MenuAction>,
+) {
+    use egui::{Color32, CornerRadius, Sense, Stroke};
+
+    const CANVAS: Vec2 = Vec2::new(470.0, 260.0);
+    let bind_of =
+        |t: PadBindTarget| -> String { labels.get(&t).cloned().unwrap_or_else(|| "-".to_string()) };
+
+    // While a capture is armed, keep frames coming: the pulse ring and
+    // the "press a key" banner animate, and the upstream render-on-
+    // change pacing would otherwise freeze them between inputs.
+    if capture.is_some() {
+        ctx.request_repaint_after(std::time::Duration::from_millis(50));
+    }
+
+    let mut still_open = *open;
+    egui::Window::new("Controls")
+        .open(&mut still_open)
+        .collapsible(false)
+        .resizable(false)
+        .anchor(Align2::CENTER_CENTER, Vec2::ZERO)
+        .show(ctx, |ui| {
+            // Capture banner / hint line above the drawing.
+            match *capture {
+                Some(target) => {
+                    ui.label(
+                        egui::RichText::new(format!(
+                            "{}  Press a key for {} ... (Esc cancels)",
+                            icons::GAMEPAD_2,
+                            target.label()
+                        ))
+                        .color(theme::MENU_ACCENT)
+                        .strong(),
+                    );
+                }
+                None => {
+                    ui.label(
+                        egui::RichText::new(
+                            "Click a control, then press the key to bind it. \
+                             Changes apply immediately and are saved.",
+                        )
+                        .color(theme::MENU_TEXT_DIM)
+                        .size(12.0),
+                    );
+                }
+            }
+            ui.add_space(4.0);
+
+            let (resp, painter) = ui.allocate_painter(CANVAS, Sense::hover());
+            let origin = resp.rect.min;
+            let at = |x: f32, y: f32| Pos2::new(origin.x + x, origin.y + y);
+            // Pulse for the armed hotspot: 2 Hz sine on the ui clock.
+            let pulse = ((ui.input(|i| i.time) * std::f64::consts::TAU).sin() * 0.5 + 0.5) as f32;
+
+            let body_fill = Color32::from_rgb(52, 56, 64);
+            let body_edge = Stroke::new(1.5, Color32::from_rgb(90, 96, 108));
+            let btn_fill = Color32::from_rgb(34, 37, 43);
+
+            // One clickable region. Paints a hover/armed ring, shows the
+            // current bind as hover text, and arms the capture on click.
+            let mut hotspot = |ui: &mut egui::Ui, rect: Rect, target: PadBindTarget| {
+                let id = resp.id.with(target.label());
+                let r = ui.interact(rect, id, Sense::click());
+                let armed = *capture == Some(target);
+                if armed {
+                    let ring = Color32::from_rgb(
+                        60 + (170.0 * pulse) as u8,
+                        180,
+                        230 - (80.0 * pulse) as u8,
+                    );
+                    ui.painter().rect_stroke(
+                        rect.expand(2.0),
+                        4.0,
+                        Stroke::new(2.0, ring),
+                        egui::StrokeKind::Outside,
+                    );
+                } else if r.hovered() {
+                    ui.painter().rect_stroke(
+                        rect.expand(2.0),
+                        4.0,
+                        Stroke::new(1.5, theme::MENU_ACCENT),
+                        egui::StrokeKind::Outside,
+                    );
+                }
+                let r = r.on_hover_text(format!(
+                    "{} - current: {} (click to rebind)",
+                    target.label(),
+                    bind_of(target)
+                ));
+                if r.clicked() {
+                    *capture = Some(target);
+                }
+            };
+
+            // Controller body: main slab + two grips.
+            painter.rect_filled(
+                Rect::from_min_max(at(30.0, 70.0), at(440.0, 185.0)),
+                CornerRadius::same(26),
+                body_fill,
+            );
+            painter.rect_filled(
+                Rect::from_min_max(at(30.0, 130.0), at(120.0, 240.0)),
+                CornerRadius::same(30),
+                body_fill,
+            );
+            painter.rect_filled(
+                Rect::from_min_max(at(350.0, 130.0), at(440.0, 240.0)),
+                CornerRadius::same(30),
+                body_fill,
+            );
+
+            // Shoulder buttons, floating above the body like the real
+            // pad's top edge. L2/R2 sit above L1/R1.
+            let shoulder = |painter: &egui::Painter, rect: Rect, text: &str| {
+                painter.rect_filled(rect, CornerRadius::same(6), btn_fill);
+                painter.text(
+                    rect.center(),
+                    Align2::CENTER_CENTER,
+                    text,
+                    FontId::proportional(11.0),
+                    Color32::from_rgb(200, 205, 215),
+                );
+            };
+            let l2 = Rect::from_min_max(at(50.0, 8.0), at(115.0, 28.0));
+            let l1 = Rect::from_min_max(at(50.0, 34.0), at(115.0, 58.0));
+            let r2 = Rect::from_min_max(at(355.0, 8.0), at(420.0, 28.0));
+            let r1 = Rect::from_min_max(at(355.0, 34.0), at(420.0, 58.0));
+            shoulder(&painter, l2, "L2");
+            shoulder(&painter, l1, "L1");
+            shoulder(&painter, r2, "R2");
+            shoulder(&painter, r1, "R1");
+            hotspot(ui, l2, PadBindTarget::L2);
+            hotspot(ui, l1, PadBindTarget::L1);
+            hotspot(ui, r2, PadBindTarget::R2);
+            hotspot(ui, r1, PadBindTarget::R1);
+
+            // D-pad: cross of two bars, four directional hotspots.
+            let dpad_c = at(85.0, 125.0);
+            painter.rect_filled(
+                Rect::from_center_size(dpad_c, Vec2::new(26.0, 82.0)),
+                CornerRadius::same(4),
+                btn_fill,
+            );
+            painter.rect_filled(
+                Rect::from_center_size(dpad_c, Vec2::new(82.0, 26.0)),
+                CornerRadius::same(4),
+                btn_fill,
+            );
+            let arm = Vec2::new(26.0, 28.0);
+            let arm_h = Vec2::new(28.0, 26.0);
+            hotspot(
+                ui,
+                Rect::from_center_size(dpad_c - Vec2::new(0.0, 27.0), arm),
+                PadBindTarget::Up,
+            );
+            hotspot(
+                ui,
+                Rect::from_center_size(dpad_c + Vec2::new(0.0, 27.0), arm),
+                PadBindTarget::Down,
+            );
+            hotspot(
+                ui,
+                Rect::from_center_size(dpad_c - Vec2::new(27.0, 0.0), arm_h),
+                PadBindTarget::Left,
+            );
+            hotspot(
+                ui,
+                Rect::from_center_size(dpad_c + Vec2::new(27.0, 0.0), arm_h),
+                PadBindTarget::Right,
+            );
+
+            // Face buttons: PS1 symbol colours on dark rounds.
+            let face_c = at(385.0, 125.0);
+            let face = |painter: &egui::Painter, c: Pos2, sym: PadBindTarget| {
+                painter.circle_filled(c, 15.0, btn_fill);
+                let s = 6.0;
+                match sym {
+                    PadBindTarget::Triangle => {
+                        let col = Color32::from_rgb(64, 190, 130);
+                        let pts = [
+                            Pos2::new(c.x, c.y - s),
+                            Pos2::new(c.x - s, c.y + s * 0.8),
+                            Pos2::new(c.x + s, c.y + s * 0.8),
+                        ];
+                        painter.line_segment([pts[0], pts[1]], Stroke::new(2.0, col));
+                        painter.line_segment([pts[1], pts[2]], Stroke::new(2.0, col));
+                        painter.line_segment([pts[2], pts[0]], Stroke::new(2.0, col));
+                    }
+                    PadBindTarget::Circle => {
+                        painter.circle_stroke(
+                            c,
+                            s,
+                            Stroke::new(2.0, Color32::from_rgb(235, 90, 90)),
+                        );
+                    }
+                    PadBindTarget::Cross => {
+                        let col = Color32::from_rgb(120, 150, 235);
+                        painter.line_segment(
+                            [Pos2::new(c.x - s, c.y - s), Pos2::new(c.x + s, c.y + s)],
+                            Stroke::new(2.0, col),
+                        );
+                        painter.line_segment(
+                            [Pos2::new(c.x - s, c.y + s), Pos2::new(c.x + s, c.y - s)],
+                            Stroke::new(2.0, col),
+                        );
+                    }
+                    PadBindTarget::Square => {
+                        painter.rect_stroke(
+                            Rect::from_center_size(c, Vec2::splat(s * 1.7)),
+                            CornerRadius::ZERO,
+                            Stroke::new(2.0, Color32::from_rgb(230, 130, 200)),
+                            egui::StrokeKind::Middle,
+                        );
+                    }
+                    _ => {}
+                }
+            };
+            let tri_c = face_c - Vec2::new(0.0, 32.0);
+            let cross_c = face_c + Vec2::new(0.0, 32.0);
+            let sq_c = face_c - Vec2::new(32.0, 0.0);
+            let cir_c = face_c + Vec2::new(32.0, 0.0);
+            face(&painter, tri_c, PadBindTarget::Triangle);
+            face(&painter, cross_c, PadBindTarget::Cross);
+            face(&painter, sq_c, PadBindTarget::Square);
+            face(&painter, cir_c, PadBindTarget::Circle);
+            let face_hit = Vec2::splat(30.0);
+            hotspot(
+                ui,
+                Rect::from_center_size(tri_c, face_hit),
+                PadBindTarget::Triangle,
+            );
+            hotspot(
+                ui,
+                Rect::from_center_size(cross_c, face_hit),
+                PadBindTarget::Cross,
+            );
+            hotspot(
+                ui,
+                Rect::from_center_size(sq_c, face_hit),
+                PadBindTarget::Square,
+            );
+            hotspot(
+                ui,
+                Rect::from_center_size(cir_c, face_hit),
+                PadBindTarget::Circle,
+            );
+
+            // Select / Start / Analog cluster in the middle.
+            let select_r = Rect::from_min_max(at(190.0, 112.0), at(222.0, 126.0));
+            let start_r = Rect::from_min_max(at(248.0, 112.0), at(280.0, 126.0));
+            painter.rect_filled(select_r, CornerRadius::same(3), btn_fill);
+            painter.rect_filled(start_r, CornerRadius::same(3), btn_fill);
+            painter.text(
+                select_r.center() - Vec2::new(0.0, 12.0),
+                Align2::CENTER_CENTER,
+                "SELECT",
+                FontId::proportional(8.0),
+                theme::MENU_TEXT_DIM,
+            );
+            painter.text(
+                start_r.center() - Vec2::new(0.0, 12.0),
+                Align2::CENTER_CENTER,
+                "START",
+                FontId::proportional(8.0),
+                theme::MENU_TEXT_DIM,
+            );
+            hotspot(ui, select_r, PadBindTarget::Select);
+            hotspot(ui, start_r, PadBindTarget::Start);
+
+            let analog_r = Rect::from_min_max(at(219.0, 140.0), at(251.0, 152.0));
+            painter.rect_filled(analog_r, CornerRadius::same(3), btn_fill);
+            painter.text(
+                analog_r.center(),
+                Align2::CENTER_CENTER,
+                "ANALOG",
+                FontId::proportional(7.0),
+                Color32::from_rgb(200, 80, 80),
+            );
+            hotspot(ui, analog_r, PadBindTarget::Analog);
+
+            // Analog sticks: the circle itself is the stick click
+            // (L3/R3); the four chips around it are the
+            // keyboard-emulated stick directions.
+            let stick = |ui: &mut egui::Ui,
+                         painter: &egui::Painter,
+                         hotspot: &mut dyn FnMut(&mut egui::Ui, Rect, PadBindTarget),
+                         c: Pos2,
+                         click: PadBindTarget,
+                         dirs: [PadBindTarget; 4]| {
+                painter.circle_filled(c, 20.0, btn_fill);
+                painter.circle_filled(c, 12.0, body_fill);
+                painter.text(
+                    c,
+                    Align2::CENTER_CENTER,
+                    match click {
+                        PadBindTarget::L3 => "L3",
+                        _ => "R3",
+                    },
+                    FontId::proportional(9.0),
+                    theme::MENU_TEXT_DIM,
+                );
+                hotspot(ui, Rect::from_center_size(c, Vec2::splat(26.0)), click);
+                // Direction chips: up, down, left, right.
+                let chip = 13.0;
+                let offs = 30.0;
+                let dirs_off = [
+                    Vec2::new(0.0, -offs),
+                    Vec2::new(0.0, offs),
+                    Vec2::new(-offs, 0.0),
+                    Vec2::new(offs, 0.0),
+                ];
+                let glyphs = ["\u{2191}", "\u{2193}", "\u{2190}", "\u{2192}"];
+                for ((target, off), glyph) in dirs.iter().zip(dirs_off).zip(glyphs) {
+                    let r = Rect::from_center_size(c + off, Vec2::splat(chip));
+                    painter.rect_filled(r, CornerRadius::same(3), btn_fill);
+                    painter.text(
+                        r.center(),
+                        Align2::CENTER_CENTER,
+                        glyph,
+                        FontId::proportional(9.0),
+                        theme::MENU_TEXT_DIM,
+                    );
+                    hotspot(ui, r, *target);
+                }
+            };
+            stick(
+                ui,
+                &painter,
+                &mut hotspot,
+                at(175.0, 200.0),
+                PadBindTarget::L3,
+                [
+                    PadBindTarget::LStickUp,
+                    PadBindTarget::LStickDown,
+                    PadBindTarget::LStickLeft,
+                    PadBindTarget::LStickRight,
+                ],
+            );
+            stick(
+                ui,
+                &painter,
+                &mut hotspot,
+                at(295.0, 200.0),
+                PadBindTarget::R3,
+                [
+                    PadBindTarget::RStickUp,
+                    PadBindTarget::RStickDown,
+                    PadBindTarget::RStickLeft,
+                    PadBindTarget::RStickRight,
+                ],
+            );
+            // Body outline last so it frames everything cleanly.
+            painter.rect_stroke(
+                Rect::from_min_max(at(30.0, 70.0), at(440.0, 185.0)),
+                CornerRadius::same(26),
+                body_edge,
+                egui::StrokeKind::Middle,
+            );
+
+            ui.add_space(6.0);
+            ui.separator();
+
+            // Complete clickable list -- same capture flow as the
+            // drawing, guaranteed to cover every target.
+            egui::ScrollArea::vertical()
+                .max_height(150.0)
+                .show(ui, |ui| {
+                    egui::Grid::new("controls-bind-grid")
+                        .num_columns(2)
+                        .striped(true)
+                        .min_col_width(150.0)
+                        .show(ui, |ui| {
+                            for target in PadBindTarget::ALL {
+                                ui.label(egui::RichText::new(target.label()).size(12.0));
+                                let armed = *capture == Some(target);
+                                let text = if armed {
+                                    "press a key...".to_string()
+                                } else {
+                                    bind_of(target)
+                                };
+                                let btn = egui::Button::new(
+                                    egui::RichText::new(text).size(12.0).color(if armed {
+                                        theme::MENU_ACCENT
+                                    } else {
+                                        Color32::from_rgb(220, 224, 232)
+                                    }),
+                                )
+                                .min_size(Vec2::new(120.0, 18.0));
+                                if ui.add(btn).clicked() {
+                                    *capture = Some(target);
+                                }
+                                ui.end_row();
+                            }
+                        });
+                });
+
+            ui.add_space(6.0);
+            ui.horizontal(|ui| {
+                if ui
+                    .button(format!("{}  Reset to defaults", icons::ROTATE_CCW))
+                    .clicked()
+                {
+                    *pending_pointer_action = Some(MenuAction::ResetControls);
+                    *capture = None;
+                }
+                ui.label(
+                    egui::RichText::new("Binding a key already in use unbinds its old control.")
+                        .color(theme::MENU_TEXT_DIM)
+                        .size(11.0),
+                );
+            });
+        });
+    *open = still_open;
+}
+
 /// Paint a save's thumbnail at `size`, loading and caching the
 /// texture on first use. Draws a plain placeholder box when `path` is
 /// `None` (no capture for this save) or fails to decode.
@@ -1785,6 +2375,12 @@ fn build_system_category(running: bool, save_count: usize) -> Category {
             action: MenuAction::OpenSaveStates,
             burn_action: None,
             value: Some("F5/F7".into()),
+        },
+        MenuItem {
+            label: "Controls".into(),
+            action: MenuAction::OpenControls,
+            burn_action: None,
+            value: None,
         },
     ];
     Category {

--- a/emu/crates/frontend/src/ui/mod.rs
+++ b/emu/crates/frontend/src/ui/mod.rs
@@ -128,6 +128,14 @@ pub fn apply_menu_action(state: &mut AppState, action: menu::MenuAction) -> Menu
             state.menu.open_save_states();
             MenuOutcome::None
         }
+        OpenControls => {
+            state.menu.open_controls();
+            MenuOutcome::None
+        }
+        ResetControls => {
+            state.reset_controls();
+            MenuOutcome::None
+        }
         PinAsTop(slot) => {
             state.pin_save_state_as_top(slot);
             MenuOutcome::None

--- a/emu/crates/frontend/src/ui/mod.rs
+++ b/emu/crates/frontend/src/ui/mod.rs
@@ -134,7 +134,10 @@ pub fn apply_menu_action(state: &mut AppState, action: menu::MenuAction) -> Menu
         }
         ResetControls => {
             state.reset_controls();
-            MenuOutcome::None
+            // The shell caches pad state keyed by the just-replaced
+            // bindings; it must throw that cache away or bits set
+            // under the old mapping can never be released.
+            MenuOutcome::ClearHostKeyboardInput
         }
         PinAsTop(slot) => {
             state.pin_save_state_as_top(slot);
@@ -220,6 +223,11 @@ pub fn apply_menu_action(state: &mut AppState, action: menu::MenuAction) -> Menu
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MenuOutcome {
     None,
+    /// The action invalidated the bindings the shell's cached keyboard
+    /// pad state was built under (Reset Controls). The shell must drop
+    /// that cache and rebuild the current frame's merged input from
+    /// the gamepad alone.
+    ClearHostKeyboardInput,
     Quit,
 }
 

--- a/emu/crates/frontend/src/ui/toolbar.rs
+++ b/emu/crates/frontend/src/ui/toolbar.rs
@@ -176,6 +176,7 @@ fn draw_toolbar_controls(ui: &mut egui::Ui, state: &mut AppState) {
     draw_buttons(ui, state);
     ui.add_space(TOOLBAR_CLUSTER_GAP);
     draw_save_states_button(ui, state);
+    draw_controls_button(ui, state);
     ui.add_space(TOOLBAR_CLUSTER_GAP);
     draw_audio_controls(ui, state);
     ui.add_space(TOOLBAR_CLUSTER_GAP);
@@ -196,6 +197,20 @@ fn draw_save_states_button(ui: &mut egui::Ui, state: &mut AppState) {
         .clicked()
     {
         state.menu.open_save_states();
+    }
+}
+
+/// Always-visible entry point into the controls panel -- rebinding
+/// mid-game (running or paused) is the point of the panel, so it must
+/// not require opening the full Menu overlay first.
+fn draw_controls_button(ui: &mut egui::Ui, state: &mut AppState) {
+    let btn = icon_button(icons::GAMEPAD_2);
+    if ui
+        .add(btn)
+        .on_hover_text("Controls (rebind keyboard keys)")
+        .clicked()
+    {
+        state.menu.open_controls();
     }
 }
 

--- a/emu/crates/psoxide-settings/src/settings.rs
+++ b/emu/crates/psoxide-settings/src/settings.rs
@@ -239,6 +239,12 @@ pub struct PortBindings {
     /// for lock-on / target toggling.
     #[serde(default)]
     pub r3: InputBinding,
+    /// Left stick click (DualShock L3). Unbound by default -- the
+    /// stock keyboard map has no comfortable key left for it -- but
+    /// rebindable from the controls panel (the L3+R3 freelook chord
+    /// needs it without a gamepad).
+    #[serde(default)]
+    pub l3: InputBinding,
     /// DualShock Analog button. This is not part of the normal
     /// button bitmask; it toggles whether the controller reports
     /// Digital (`0x41`) or Analog (`0x73`) poll IDs.
@@ -272,6 +278,7 @@ impl Default for PortBindings {
             left_stick: default_port1_left_stick_bindings(),
             right_stick: default_port1_right_stick_bindings(),
             r3: default_port1_r3_binding(),
+            l3: InputBinding::Unbound,
             analog: default_port1_analog_binding(),
         }
     }
@@ -336,6 +343,7 @@ impl Default for InputSettings {
                 left_stick: StickBindings::unbound(),
                 right_stick: StickBindings::unbound(),
                 r3: InputBinding::Unbound,
+                l3: InputBinding::Unbound,
                 analog: InputBinding::Unbound,
             },
         }

--- a/emu/crates/psoxide-settings/src/settings.rs
+++ b/emu/crates/psoxide-settings/src/settings.rs
@@ -253,22 +253,27 @@ pub struct PortBindings {
 }
 
 impl Default for PortBindings {
-    /// Default keyboard mapping. Chosen so a right-hander can hold
-    /// the d-pad on the left hand (arrow keys) and the action
-    /// cluster on the right (X / C / V / D forms a rough diamond).
+    /// Default keyboard mapping: arrows on the left hand, the face
+    /// cluster on the right hand's home row (F/G/H + X above).
     ///
-    /// Not claiming this is optimal -- users will want to rebind.
-    /// It's just "works immediately on a fresh install."
+    /// The face buttons deliberately avoid the classic Z/X/C bottom-row
+    /// cluster: on common 2-key-rollover membrane keyboards those sit
+    /// on shared matrix lines with the arrow keys, so a third
+    /// simultaneous press (hold a direction + jump + dash) is silently
+    /// dropped by the keyboard itself before the OS ever sees it.
+    /// Arrows + F/G/H/X was verified to register three-plus
+    /// simultaneous keys on boards where arrows + Z/X/C ghosts.
+    /// Users can still rebind everything from the controls panel.
     fn default() -> Self {
         Self {
             up: InputBinding::named("ArrowUp"),
             down: InputBinding::named("ArrowDown"),
             left: InputBinding::named("ArrowLeft"),
             right: InputBinding::named("ArrowRight"),
-            cross: InputBinding::Character('x'),
-            circle: InputBinding::Character('c'),
-            square: InputBinding::Character('z'),
-            triangle: InputBinding::Character('s'),
+            cross: InputBinding::Character('f'),
+            circle: InputBinding::Character('g'),
+            square: InputBinding::Character('h'),
+            triangle: InputBinding::Character('x'),
             l1: InputBinding::Character('q'),
             r1: InputBinding::Character('e'),
             l2: InputBinding::Character('1'),


### PR DESCRIPTION
# Keyboard input overhaul: reliable multi-key play, SOCD, rebindable controls panel

## The problem this started from

Holding one bound key and pressing a second could drop the first button — running while jumping felt like the emulator only honoured one key at a time. Chasing that surfaced three distinct layers of keyboard-input problems, each fixed by one commit here; the fourth commit adds the tooling so users can diagnose and solve the *hardware* layer themselves.

## Commit 1 — `fix(frontend)`: match pad bindings against physical keys

**Root cause of the dropped keys:** bindings were matched against winit's **logical** `Key` — the character the active layout translates each keystroke into. Windows re-runs that translation on every keystroke, and on layouts with dead keys near the default control cluster (ABNT2, International-US, …) a still-held key's events can flip from `Key::Character` to `Key::Dead`/`Unidentified` the moment a second key goes down. Its `Released` then no longer matched any binding (bit stuck wedged), or its re-`Pressed` stopped matching (button read as dropped).

**Fix:** match on `PhysicalKey`/`KeyCode` — straight from the hardware scancode (the DOM `code` on web), independent of layout, modifier state, and other held keys. `Character` bindings map through a fixed US-QWERTY position table (bindings are stored as the character that position produces on US-QWERTY), so the persisted `settings.ron` format is unchanged. Pad mask and keyboard-stick state are also cleared on focus loss: the OS doesn't reliably deliver `Released` for keys still held during Alt-Tab, which left buttons stuck "held".

Menu navigation and text-like UI input still use the logical key — layout translation is exactly what you want there.

## Commit 2 — `feat(frontend)`: SOCD resolution, last press wins

The real PS1 d-pad is a physical rocker: left+right can never be down together, so games were never written for both bits set and react unpredictably (most keep the old direction — which on keyboard read as "I can't turn around without releasing the other key first"). The guest now never sees opposing cardinals: per pair, the most recent press wins, and releasing it re-exposes the still-held opposite. No recorded recency resolves to neutral, which is what the rocker does mid-travel. Applied to the merged keyboard+gamepad mask.

## Commit 3 — `feat(frontend)`: controls panel

A painter-drawn PS1 controller where every part is a click-to-rebind hotspot, opened from a new always-visible toolbar gamepad icon or the System menu row — **while the game is running or paused**. That's the point of the panel: bindings are read live on every key event, so a rebind applies on the very next press, and each change persists to `settings.ron` immediately. No restart, no relaunch, no separate settings screen.

- Full DualShock coverage: d-pad, face buttons (drawn with their symbol colours), L1/L2/R1/R2, Start/Select, **L3** (new `PortBindings` field, serde-default `Unbound`, so old settings files load unchanged), R3, the Analog mode toggle, and the keyboard-emulated stick directions for both sticks.
- Capture flow: click a control → "press a key" → done. Escape cancels. While a capture is armed the keyboard is owned outright, so binding `g` or `F5` doesn't also fire their global meanings.
- Binding a key already in use unbinds its old control — one key silently driving two inputs is never what the user meant.
- The capturable key set deliberately includes the whole numpad, F-keys, and punctuation (with `named_key_codes` extended to match everything the capture can persist): those regions are prime real estate for dodging keyboard-matrix ghosting — see below.
- Reset-to-defaults button.

## Commit 4 — `feat(frontend)`: ghost-aware defaults + live held view

**Why change the default keys:** the classic Z/X/C face cluster sits on shared matrix lines with the arrow keys on common 2-key-rollover membrane keyboards. Hold a direction + jump + dash and the keyboard itself silently drops the third key — no OS event is ever generated, so no emulator can fix it in software (verified by comparing synthetic 3-key injection, which registers fine, against physical presses, which don't). Defaults move to **F/G/H + X for Triangle**: verified to register 3+ simultaneous keys together with arrows on a board where arrows+Z/X/C ghosts. Existing `settings.ron` files are untouched — only fresh installs and "Reset to defaults" see the new map.

**Making the invisible visible:** controls now light up green on the panel while their key is physically held. That turns the panel into a live rollover tester — hold your movement + action combo and see exactly which keys the keyboard delivered. Users hitting ghosting on their own board can find a working combination in seconds and rebind to it on the spot. Each control also shows its current key right on the drawing, the fallback list is grouped by cluster, and Escape closes the panel before touching the menu overlay.

## Commit 5 — `feat(frontend)`: visual pass on the panel

The pad drawing follows the PS1 controller's actual construction — two circular pods carrying the d-pad and face cluster, a narrower bridge, capsule grips flaring down-outward — with the whole drawing (positions, sizes, fonts) routed through a single 1.35× scale constant.

This pass was iterated against **screenshots of the running app**, which caught two things code inspection missed: the Menu overlay paints on a mid-layer painter above ordinary windows, so the category list drew straight over the panel (it now pins to `Order::Foreground`); and the menu font has no U+2190..2193 arrow glyphs — the d-pad/stick labels rendered as .notdef boxes (ASCII `^ v < >` stand-ins now, plus `Bksp`/`Spc`/`Num*` compactions). `PSOXIDE_OPEN_CONTROLS=1` (in the `PSOXIDE_AUTORUN` tradition) opens the panel at startup so future drawing tweaks can be screenshotted without clicking through the UI.

## Testing

- `cargo test -p frontend -p psoxide-settings`: 167 passed (new unit tests: capture→match round-trip for every key family, SOCD pair resolution, updated default-mapping tests).
- `cargo fmt` clean against the pinned rustfmt.
- Hand-tested on Windows on a 2KRO membrane keyboard: with the old Z/X/C defaults, a third simultaneous key (direction + jump + dash) was dropped by the keyboard itself; the new arrows + F/G/H/X defaults register 3+ simultaneous keys on the same board. The working combination was found using the panel's live rebind flow with the emulator running — which is exactly the workflow this PR is meant to enable.
- Panel visuals verified against screenshots of the running app across three iterations.

