### PR TITLE
Model measured PS1 pipeline timing

### DIFF
--- a/emu/crates/emulator-core/src/bus.rs
+++ b/emu/crates/emulator-core/src/bus.rs
@@ -1015,6 +1015,7 @@ impl Bus {
                     }
                 }
                 EventSlot::SpuDma => {
+                    self.spu.end_dma();
                     if self.complete_dma_channel(4) {
                         dma_edge = true;
                     }
@@ -1675,6 +1676,7 @@ impl Bus {
             // hangs forever.
             return Some(0);
         }
+        self.spu.begin_dma(self.cycles);
         let sync_mode = (ch.channel_control >> 9) & 0x3;
         let bcr = ch.block_control;
         // BCR length is a count of 32-bit DMA words. Each transferred word
@@ -1889,7 +1891,10 @@ impl Bus {
             }
         } else {
             for _ in 0..total_words {
-                let word = self.gpu.read32(crate::gpu::GP0_ADDR).unwrap_or(0);
+                let word = self
+                    .gpu
+                    .read32_at(crate::gpu::GP0_ADDR, self.cycles)
+                    .unwrap_or(0);
                 write_ram_u32(&mut self.ram[..], addr, word);
                 addr = addr.wrapping_add(step);
             }
@@ -1930,7 +1935,10 @@ impl Bus {
             }
         } else {
             for _ in 0..total_words {
-                let word = self.gpu.read32(crate::gpu::GP0_ADDR).unwrap_or(0);
+                let word = self
+                    .gpu
+                    .read32_at(crate::gpu::GP0_ADDR, self.cycles)
+                    .unwrap_or(0);
                 write_ram_u32(&mut self.ram[..], addr, word);
                 addr = addr.wrapping_add(step);
             }
@@ -2094,7 +2102,8 @@ impl Bus {
         if Dma::contains(phys) {
             return self.dma.read8(phys);
         }
-        if let Some(value) = self.gpu.read32(phys & !3) {
+        if let Some(value) = self.gpu.read32_at(phys & !3, self.cycles) {
+            self.service_gpu_irq();
             return (value >> ((phys & 3) * 8)) as u8;
         }
         if Spu::contains(phys) {
@@ -2201,7 +2210,8 @@ impl Bus {
         if Spu::contains(phys) {
             return self.spu.read16_at(phys, self.cycles);
         }
-        if let Some(value) = self.gpu.read32(phys & !3) {
+        if let Some(value) = self.gpu.read32_at(phys & !3, self.cycles) {
+            self.service_gpu_irq();
             return (value >> ((phys & 2) * 8)) as u16;
         }
         if Sio0::contains(phys) {
@@ -2340,7 +2350,8 @@ impl Bus {
         if Dma::contains(phys) {
             return self.dma.read32(phys);
         }
-        if let Some(v) = self.gpu.read32(phys) {
+        if let Some(v) = self.gpu.read32_at(phys, self.cycles) {
+            self.service_gpu_irq();
             return v;
         }
         if Spu::contains(phys) {
@@ -2483,7 +2494,7 @@ impl Bus {
             }
             return;
         }
-        if self.gpu.write32(phys, value) {
+        if self.gpu.write32_at(phys, value, self.cycles) {
             self.service_gpu_irq();
             if phys == crate::gpu::GP1_ADDR && (value >> 24) == 0x08 {
                 if value & (1 << 3) != 0 {
@@ -2656,7 +2667,7 @@ impl Bus {
             return true;
         }
         let aligned = phys & !3;
-        if self.gpu.write32(aligned, source) {
+        if self.gpu.write32_at(aligned, source, self.cycles) {
             self.service_gpu_irq();
             return true;
         }
@@ -2830,7 +2841,7 @@ impl Bus {
             self.sio1.write16(phys, value);
             return;
         }
-        if self.gpu.write32(phys & !3, value as u32) {
+        if self.gpu.write32_at(phys & !3, value as u32, self.cycles) {
             self.service_gpu_irq();
             return;
         }
@@ -3111,6 +3122,8 @@ mod tests {
         let mut bus = Bus::new(synthetic_bios()).unwrap();
 
         bus.write32(crate::gpu::GP0_ADDR, 0x1F00_0000);
+        assert_eq!(bus.read32(crate::gpu::GP1_ADDR) & (1 << 24), 0);
+        bus.add_cycles(crate::gpu::GP1_STATUS_LATCH_CYCLES as u32);
         assert_ne!(bus.read32(crate::gpu::GP1_ADDR) & (1 << 24), 0);
         assert_ne!(
             bus.read32(IRQ_STAT_ADDR) & (1 << (IrqSource::Gpu as u32)),
@@ -3118,6 +3131,8 @@ mod tests {
         );
 
         bus.write32(crate::gpu::GP1_ADDR, 0x0200_0000);
+        assert_ne!(bus.read32(crate::gpu::GP1_ADDR) & (1 << 24), 0);
+        bus.add_cycles(crate::gpu::GP1_STATUS_LATCH_CYCLES as u32);
         assert_eq!(bus.read32(crate::gpu::GP1_ADDR) & (1 << 24), 0);
         assert_eq!(
             bus.read32(IRQ_STAT_ADDR) & (1 << (IrqSource::Gpu as u32)),

--- a/emu/crates/emulator-core/src/cpu.rs
+++ b/emu/crates/emulator-core/src/cpu.rs
@@ -45,17 +45,11 @@ const CACHE_CONTROL_BIOS_NORMAL: u32 = 0x0001_E988;
 /// (data reg 31) is readable. A read inside this window returns the prior
 /// count -- the off-by-one observed on real hardware for a back-to-back
 /// `mtc2 lzcs; mfc2 lzcr`.
-/// Measured on a PAL SCPH-9902 (settle sweep, 2026-07-15): LZCR is still
-/// stale with one intervening instruction and becomes visible with two.
-const LZCR_RESULT_LATENCY: u64 = 3;
-/// Short fallback window for commands other than NCLIP. NCLIP has a distinct
-/// measured accumulation phase and sets its own ready point below.
+/// Final burned-EXE capture on a PAL SCPH-9902 (2026-07-15): one intervening
+/// instruction is sufficient; only the truly back-to-back read is stale.
+const LZCR_RESULT_LATENCY: u64 = 2;
+/// Short result window for commands that write MAC0.
 const MAC0_RESULT_LATENCY: u64 = 2;
-/// A PAL SCPH-9902 returns NCLIP's partially accumulated MAC0 through the
-/// +48-nop probe and the final value at +64. The partial value is the four
-/// terms that do not involve SY0; this held exactly across the winding and
-/// quarter/half/double-magnitude captures.
-const NCLIP_MAC0_RESULT_LATENCY: u64 = 64;
 
 /// Errors raised during instruction execution.
 #[derive(Error, Debug, PartialEq, Eq)]
@@ -161,21 +155,44 @@ pub struct Cpu {
     /// Hardware GTE result-read latency. Unlike MAC1-3/SXY/SZ, MAC0 (data
     /// reg 24) and LZCR (data reg 31) are not always readable the instant
     /// their producing operation issues. The eager GTE core computes the
-    /// final values immediately, so these fields preserve what silicon
-    /// exposes during the settling window. For NCLIP that is a measured
-    /// partial accumulator value, not simply the preceding MAC0.
-    ///
-    /// Confirmed on PAL SCPH-9902 hardware (2026-07-15): LZCR remains stale
-    /// through one intervening instruction; NCLIP exposes its four non-SY0
-    /// terms from +1 through +48 nops and its completed MAC0 at +64.
+    /// result immediately, so these fields preserve what silicon exposes
+    /// during the short settling window.
     gte_mac0_ready_at: u64,
     gte_mac0_stale: u32,
     gte_lzcr_ready_at: u64,
     gte_lzcr_stale: u32,
-    /// Tick of the most recent MTC2/CTC2. A freshly loaded input pipeline is
-    /// what triggers the captured MAC0 settling behaviour; commands issued
-    /// clear of COP2 writes continue to serve their eager result immediately.
+    /// Tick of the most recent MTC2/CTC2.
     gte_last_write_tick: u64,
+    /// NCLIP samples SXY2 in two different pipeline phases. When MTC2 SXY2
+    /// immediately precedes NCLIP, the early `+SX1*SY2 + SX2*SY0` products
+    /// can see the previous SXY2 while the later negative products see the
+    /// current register. Packed SXY writes forward the new Y into that early
+    /// phase; spaced writes do not. This history/cadence rule reproduces both
+    /// burned-EXE instruction shapes measured on the SCPH-9902 without a
+    /// fabricated magnitude-dependent 64-cycle latency.
+    gte_sxy2_write_tick: u64,
+    gte_prev_sxy2_x: i16,
+    gte_prev_sxy2_y: i16,
+    gte_sxy_write_tick: [u64; 3],
+    /// RTPT leaves the SXY result pipeline active across following NCLIPs.
+    /// In that state, a non-packed full SXY rewrite cannot forward SXY2.y to
+    /// NCLIP's first product. Consecutive NCLIPs retain the state; any other
+    /// GTE command drains/replaces it.
+    gte_nclip_rtpt_history: bool,
+    /// OP's first MAC row can consume the previous IR3 when the command
+    /// immediately follows MTC2 IR3. The burned test's predecessor left
+    /// IR3=0x0567, producing MAC1=-1074 exactly; the later rows see the new
+    /// IR3=0x0600.
+    gte_ir3_write_tick: u64,
+    gte_prev_ir3: u32,
+    gte_last_mtc2_ir3: u32,
+    /// Most recent CPU write to MAC0..MAC3. An immediately following GTE
+    /// command can reach the same result write port while MTC2 still owns it;
+    /// the CPU write wins that one component (observed as OP MAC3 remaining
+    /// zero while MAC1/MAC2 complete normally).
+    gte_mac_write_tick: u64,
+    gte_mac_write_reg: u8,
+    gte_mac_write_value: u32,
     /// Diagnostic: bypass the MAC0/LZCR stale-read model entirely.
     /// Seeded from an env var at [`Cpu::new`] -- excluded from save
     /// states (loading doesn't re-run `Cpu::new`, so this and its two
@@ -292,6 +309,17 @@ impl Cpu {
             gte_lzcr_ready_at: 0,
             gte_lzcr_stale: 0,
             gte_last_write_tick: 0,
+            gte_sxy2_write_tick: 0,
+            gte_prev_sxy2_x: 0,
+            gte_prev_sxy2_y: 0,
+            gte_sxy_write_tick: [0; 3],
+            gte_nclip_rtpt_history: false,
+            gte_ir3_write_tick: 0,
+            gte_prev_ir3: 0,
+            gte_last_mtc2_ir3: 0,
+            gte_mac_write_tick: 0,
+            gte_mac_write_reg: u8::MAX,
+            gte_mac_write_value: 0,
             // Default ON with the SILICON-MEASURED window (settle sweeps,
             // 2026-06-10): MAC0/LZCR are stale only for the immediately-next
             // instruction; one intervening instruction settles them. The
@@ -408,6 +436,17 @@ impl Cpu {
         self.gte_mac0_stale = 0;
         self.gte_lzcr_ready_at = 0;
         self.gte_lzcr_stale = 0;
+        self.gte_sxy2_write_tick = 0;
+        self.gte_prev_sxy2_x = 0;
+        self.gte_prev_sxy2_y = 0;
+        self.gte_sxy_write_tick = [0; 3];
+        self.gte_nclip_rtpt_history = false;
+        self.gte_ir3_write_tick = 0;
+        self.gte_prev_ir3 = 0;
+        self.gte_last_mtc2_ir3 = 0;
+        self.gte_mac_write_tick = 0;
+        self.gte_mac_write_reg = u8::MAX;
+        self.gte_mac_write_value = 0;
         self.hilo_busy_until = 0;
         self.pending_exception_pc = None;
         self.hle_exception_active = false;
@@ -1139,6 +1178,10 @@ impl Cpu {
                 && self.tick.wrapping_sub(self.gte_v0xy_write_tick) <= self.gte_v0x_window
             {
                 self.cop2.execute_with_stale_v0x(instr, self.gte_prev_v0x);
+            } else if (instr & 0x3F) == 0x0C && self.tick.wrapping_sub(self.gte_ir3_write_tick) <= 1
+            {
+                self.cop2
+                    .execute_op_with_stale_ir3(instr, self.gte_prev_ir3 as i16);
             } else {
                 self.cop2.execute(instr);
             }
@@ -1151,25 +1194,52 @@ impl Cpu {
             // than a deadline ending on the final internal cycle.
             self.gte_busy_until = bus.cycles() + Gte::command_cycles(instr) as u64 + 1;
             let recent_cop2_write = self.tick.wrapping_sub(self.gte_last_write_tick) <= 2;
-            if (instr & 0x3F) == 0x06 && recent_cop2_write {
-                // NCLIP evaluates
-                //   x0*y1 + x1*y2 + x2*y0 - x0*y2 - x1*y0 - x2*y1.
-                // Silicon exposes the four non-SY0 terms while its final
-                // accumulation phase is pending.
+            if (instr & 0x3F) == 0x06 && self.tick.wrapping_sub(self.gte_sxy2_write_tick) <= 2 {
+                // NCLIP's two positive SXY2 products are its early phase.
+                // SXY2.x is not forwarded from the immediately preceding
+                // MTC2. SXY2.y is forwarded only by the packed (two-cycle)
+                // SXY0/SXY1/SXY2 write cadence emitted by the hot path.
                 let sxy0 = self.cop2.read_data(12);
                 let sxy1 = self.cop2.read_data(13);
                 let sxy2 = self.cop2.read_data(14);
                 let x0 = sxy0 as u16 as i16 as i64;
+                let y0 = (sxy0 >> 16) as u16 as i16 as i64;
                 let y1 = (sxy1 >> 16) as u16 as i16 as i64;
                 let x1 = sxy1 as u16 as i16 as i64;
                 let y2 = (sxy2 >> 16) as u16 as i16 as i64;
                 let x2 = sxy2 as u16 as i16 as i64;
-                self.gte_mac0_stale = (x0 * y1 + x1 * y2 - x0 * y2 - x2 * y1) as u32;
-                self.gte_mac0_ready_at = self.tick + NCLIP_MAC0_RESULT_LATENCY;
+                let old_x2 = self.gte_prev_sxy2_x as i64;
+                let sxy01_gap = self.gte_sxy_write_tick[1].wrapping_sub(self.gte_sxy_write_tick[0]);
+                let sxy12_gap = self.gte_sxy_write_tick[2].wrapping_sub(self.gte_sxy_write_tick[1]);
+                let spaced_sxy_triplet =
+                    self.gte_nclip_rtpt_history && sxy01_gap == 3 && sxy12_gap == 3;
+                let early_y2 = if spaced_sxy_triplet {
+                    self.gte_prev_sxy2_y as i64
+                } else {
+                    y2
+                };
+                let mac0 = x0 * y1 + x1 * early_y2 + old_x2 * y0 - x0 * y2 - x1 * y0 - x2 * y1;
+                self.cop2.write_data(24, mac0 as u32);
+                self.gte_mac0_stale = mac0 as u32;
+                self.gte_mac0_ready_at = self.tick + MAC0_RESULT_LATENCY;
             } else if recent_cop2_write {
                 self.gte_mac0_ready_at = self.tick + MAC0_RESULT_LATENCY;
             } else {
                 self.gte_mac0_ready_at = self.tick; // result is immediately readable
+            }
+            if (24..=27).contains(&self.gte_mac_write_reg)
+                && self.tick.wrapping_sub(self.gte_mac_write_tick) <= 1
+            {
+                self.cop2
+                    .write_data(self.gte_mac_write_reg, self.gte_mac_write_value);
+                if self.gte_mac_write_reg == 24 {
+                    self.gte_mac0_stale = self.gte_mac_write_value;
+                }
+            }
+            match instr & 0x3F {
+                0x30 => self.gte_nclip_rtpt_history = true,
+                0x06 => {}
+                _ => self.gte_nclip_rtpt_history = false,
             }
             return Ok(());
         }
@@ -1285,6 +1355,29 @@ impl Cpu {
             // phase with this stale value (HWB-010 hazard model).
             self.gte_prev_v0x = self.cop2.read_data(0) as u16 as i16;
             self.gte_v0xy_write_tick = self.tick;
+        }
+        if (12..=14).contains(&rd) {
+            self.gte_sxy_write_tick[(rd - 12) as usize] = self.tick;
+        }
+        if rd == 14 {
+            let previous = self.cop2.read_data(14);
+            self.gte_prev_sxy2_x = previous as u16 as i16;
+            self.gte_prev_sxy2_y = (previous >> 16) as u16 as i16;
+            self.gte_sxy2_write_tick = self.tick;
+        }
+        if rd == 11 {
+            // The forwarding latch retains the previous CPU-supplied IR3,
+            // not an intervening command's architectural IR3 result. In the
+            // burned sequence SQR changes visible IR3 to 466, but OP's first
+            // row still consumes the earlier MTC2 value 0x0567.
+            self.gte_prev_ir3 = self.gte_last_mtc2_ir3;
+            self.gte_last_mtc2_ir3 = self.gpr(rt);
+            self.gte_ir3_write_tick = self.tick;
+        }
+        if (24..=27).contains(&rd) {
+            self.gte_mac_write_tick = self.tick;
+            self.gte_mac_write_reg = rd;
+            self.gte_mac_write_value = self.gpr(rt);
         }
         self.cop2.write_data(rd, self.gpr(rt));
         Ok(())
@@ -2621,6 +2714,121 @@ mod tests {
         cpu.seed_from_exe(0x8000_3000, 0, None);
 
         assert_eq!(cpu.cop0[12], 0x4000_0401);
+    }
+
+    #[test]
+    fn nclip_uses_previous_sxy2_x_in_early_pipeline_stage() {
+        let mut cpu = Cpu::new();
+        let mut bus = Bus::new(synthetic_bios_with_first_word(0)).unwrap();
+        // Scene A, immediately following scene C. Hardware returned 0x7674:
+        // current terms plus SY0 * (previous SX2 - current SX1).
+        cpu.cop2.write_data(12, 0x006e_0095);
+        cpu.cop2.write_data(13, 0xffe2_0094);
+        cpu.cop2.write_data(14, 0xffd2_0194); // previous scene-C SXY2
+        cpu.gte_sxy_write_tick[0] = 6;
+        cpu.gte_sxy_write_tick[1] = 8;
+        cpu.gprs[8] = 0xffde_00dc; // new scene-A SXY2
+        cpu.tick = 10;
+        cpu.op_mtc2(0x4888_7000, &bus).unwrap();
+        cpu.tick = 12;
+
+        cpu.dispatch_cop2(0x4a00_0006, &mut bus).unwrap();
+
+        assert_eq!(cpu.cop2.read_data(24), 0x0000_7674);
+    }
+
+    #[test]
+    fn nclip_sxy_write_cadence_controls_early_y_forwarding() {
+        let run = |write_gap: u64| {
+            let mut cpu = Cpu::new();
+            let mut bus = Bus::new(synthetic_bios_with_first_word(0)).unwrap();
+            // RTPT-E's settled SXY2 is (-36, -152). Scene A overwrites all
+            // three SXY registers before NCLIP using either of the two exact
+            // instruction cadences found in the burned executable.
+            cpu.cop2.write_data(14, 0xff68_ffdc);
+            cpu.gte_nclip_rtpt_history = true;
+            for (index, (rd, value)) in [
+                (12u8, 0x006e_0095),
+                (13u8, 0xffe2_0094),
+                (14u8, 0xffde_00dc),
+            ]
+            .into_iter()
+            .enumerate()
+            {
+                cpu.gprs[8] = value;
+                cpu.tick = 10 + index as u64 * write_gap;
+                cpu.op_mtc2(0x4888_0000 | (u32::from(rd) << 11), &bus)
+                    .unwrap();
+            }
+            cpu.tick += 1;
+            cpu.dispatch_cop2(0x4a00_0006, &mut bus).unwrap();
+            cpu.cop2.read_data(24)
+        };
+
+        // Packed writes forward the new Y but not X; spaced writes retain
+        // both components for the early positive products.
+        assert_eq!(run(2), 0xffff_b964);
+        assert_eq!(run(3), 0xffff_752c);
+    }
+
+    #[test]
+    fn lzcr_is_stale_only_for_back_to_back_read() {
+        let mut cpu = Cpu::new();
+        let bus = Bus::new(synthetic_bios_with_first_word(0)).unwrap();
+        cpu.cop2.write_data(30, 0x00ff_ffff); // old LZCR = 8
+        cpu.gprs[8] = 1; // new LZCR = 31
+        cpu.tick = 10;
+        cpu.op_mtc2(0x4888_f000, &bus).unwrap();
+
+        cpu.tick = 11;
+        assert_eq!(cpu.gte_read_data_latency(&bus, 31), 8);
+        cpu.tick = 12;
+        assert_eq!(cpu.gte_read_data_latency(&bus, 31), 31);
+    }
+
+    #[test]
+    fn immediate_mtc2_mac_write_wins_same_component_command_writeback() {
+        let mut cpu = Cpu::new();
+        let mut bus = Bus::new(synthetic_bios_with_first_word(0)).unwrap();
+        cpu.cop2.write_control(0, 0x1000);
+        cpu.cop2.write_control(2, 0x2000);
+        cpu.cop2.write_control(4, 0x3000);
+        cpu.cop2.write_data(9, 0x0400);
+        cpu.cop2.write_data(10, 0x0500);
+        cpu.cop2.write_data(11, 0x0600);
+        cpu.gprs[8] = 0;
+        cpu.tick = 10;
+        cpu.op_mtc2(0x4888_d800, &bus).unwrap(); // MTC2 $t0, MAC3
+        cpu.tick = 11;
+
+        cpu.dispatch_cop2(0x4a08_000c, &mut bus).unwrap(); // OP sf=1
+
+        assert_eq!(cpu.cop2.read_data(25), 0xffff_fd00);
+        assert_eq!(cpu.cop2.read_data(26), 0x0000_0600);
+        assert_eq!(cpu.cop2.read_data(27), 0x0000_0000);
+    }
+
+    #[test]
+    fn immediate_mtc2_ir3_reaches_op_after_first_mac_row() {
+        let mut cpu = Cpu::new();
+        let mut bus = Bus::new(synthetic_bios_with_first_word(0)).unwrap();
+        cpu.cop2.write_control(0, 0x1000);
+        cpu.cop2.write_control(2, 0x2000);
+        cpu.cop2.write_control(4, 0x3000);
+        cpu.cop2.write_data(9, 0x0400);
+        cpu.cop2.write_data(10, 0x0500);
+        cpu.cop2.write_data(11, 0x01d2); // architectural SQR result = 466
+        cpu.gte_last_mtc2_ir3 = 0x0567; // prior CPU-written SQR input
+        cpu.gprs[8] = 0x0600;
+        cpu.tick = 10;
+        cpu.op_mtc2(0x4888_5800, &bus).unwrap(); // MTC2 $t0, IR3
+        cpu.tick = 11;
+
+        cpu.dispatch_cop2(0x4a08_000c, &mut bus).unwrap();
+
+        assert_eq!(cpu.cop2.read_data(25), 0xffff_fbce);
+        assert_eq!(cpu.cop2.read_data(26), 0x0000_0600);
+        assert_eq!(cpu.cop2.read_data(27), 0xffff_fd00);
     }
 
     #[test]

--- a/emu/crates/emulator-core/src/gpu.rs
+++ b/emu/crates/emulator-core/src/gpu.rs
@@ -42,6 +42,11 @@ pub const GP0_ADDR: u32 = 0x1F80_1810;
 /// Physical address of the GP1 / GPUSTAT port.
 pub const GP1_ADDR: u32 = 0x1F80_1814;
 
+/// GP1 status latches become CPU-visible after the first immediately
+/// following GPUSTAT read but before the second. The captured SCPH-9902
+/// transition lands twelve CPU clock cycles after the command write.
+pub(crate) const GP1_STATUS_LATCH_CYCLES: u64 = 12;
+
 /// `#[serde(default = ...)]` target for the `[u32; 256]`-shaped
 /// diagnostic opcode histograms below -- `Default` only covers arrays
 /// up to length 32 on stable Rust, so a skipped 256-entry histogram
@@ -360,6 +365,11 @@ pub struct Gpu {
     /// Latched when GP1(00h/02h) acknowledges IRQ1. The bus consumes
     /// this and clears I_STAT bit 1.
     irq_acknowledged: bool,
+    /// Posted GP1 commands whose GPUSTAT-visible effect has not reached the
+    /// status latch yet. Display geometry is updated at write time; only the
+    /// status bits and IRQ acknowledge are delayed.
+    #[serde(default)]
+    pending_gp1_status: std::collections::VecDeque<(u64, u32)>,
 }
 
 /// Public snapshot of the GPU's display configuration, read by the
@@ -515,6 +525,7 @@ impl Gpu {
             gp1_write_history: Vec::new(),
             irq_requested: false,
             irq_acknowledged: false,
+            pending_gp1_status: std::collections::VecDeque::new(),
         }
     }
 
@@ -851,13 +862,34 @@ impl Gpu {
     /// VRAM→CPU transfer one word at a time; the GP1 (GPUSTAT) port
     /// stays side-effect-free.
     pub fn read32(&mut self, phys: u32) -> Option<u32> {
+        self.read32_at(phys, u64::MAX)
+    }
+
+    /// MMIO read with CPU-cycle context so posted GP1 status writes can
+    /// mature between two consecutive GPUSTAT reads.
+    pub fn read32_at(&mut self, phys: u32, now: u64) -> Option<u32> {
+        self.apply_pending_gp1_status(now);
         match phys {
             GP0_ADDR => Some(self.read_gpuread()),
-            GP1_ADDR => Some(self.status.read(
-                self.vram_download.is_some(),
-                !self.is_busy(),
-                !self.is_dma_busy(),
-            )),
+            GP1_ADDR => {
+                let mut value = self.status.read(
+                    self.vram_download.is_some(),
+                    !self.is_busy(),
+                    !self.is_dma_busy(),
+                );
+                // IRQ1 first deasserts the two ready signals. The DMA-request
+                // output is a separate latch and retains its pre-command
+                // value until the IRQ/status event lands (C202 -> D702 on the
+                // measured direction-2 path, rather than C002 -> D702).
+                if self
+                    .pending_gp1_status
+                    .iter()
+                    .any(|(_, command)| command >> 24 == 0x1F)
+                {
+                    value |= 1 << 25;
+                }
+                Some(value)
+            }
             _ => None,
         }
     }
@@ -1067,6 +1099,11 @@ impl Gpu {
         let textured_poly_cost = |pixels: u64| scale_gpu_pixels(pixels, 179, 64);
 
         match op {
+            // GP0(1Fh) traverses the command input path before IRQ1 and the
+            // ready flags reach GPUSTAT. On SCPH-9902 the first immediately
+            // following read has bits 26/28 clear and the second has them
+            // set, the same edge measured for the IRQ status latch itself.
+            0x1F => GP1_STATUS_LATCH_CYCLES,
             // GP0(02h) has a dedicated fast fill engine. Silicon moves a
             // little over twelve pixels per CPU cycle for this path.
             0x02 => {
@@ -1254,9 +1291,30 @@ impl Gpu {
     /// Dispatch an MMIO write inside the GPU window. Returns `true` if
     /// the address belonged to the GPU.
     pub fn write32(&mut self, phys: u32, value: u32) -> bool {
+        self.write32_inner(phys, value, None)
+    }
+
+    /// MMIO write with CPU-cycle context. GP1(02h) IRQ acknowledge and
+    /// GP1(04h) DMA-direction changes are posted to GPUSTAT; direct host-side
+    /// callers retain the immediate legacy behaviour through [`Gpu::write32`].
+    pub fn write32_at(&mut self, phys: u32, value: u32, now: u64) -> bool {
+        self.write32_inner(phys, value, Some(now))
+    }
+
+    fn write32_inner(&mut self, phys: u32, value: u32, now: Option<u64>) -> bool {
         match phys {
             GP0_ADDR => {
+                let irq_deadline = now
+                    .filter(|_| value >> 24 == 0x1f)
+                    .map(|now| now.saturating_add(GP1_STATUS_LATCH_CYCLES));
+                let old_irq_bit = self.status.raw & (1 << 24);
+                let old_irq_requested = self.irq_requested;
                 self.gp0_write(value, false);
+                if let Some(deadline) = irq_deadline {
+                    self.status.raw = (self.status.raw & !(1 << 24)) | old_irq_bit;
+                    self.irq_requested = old_irq_requested;
+                    self.pending_gp1_status.push_back((deadline, 0x1f00_0000));
+                }
                 true
             }
             GP1_ADDR => {
@@ -1266,14 +1324,42 @@ impl Gpu {
                     self.gp1_write_history.remove(0);
                 }
                 self.gp1_write_history.push(value);
-                if matches!(op, 0x00 | 0x02) {
-                    self.irq_acknowledged = true;
-                }
                 self.apply_gp1_display(value);
-                self.status.gp1_write(value);
+                if let Some(now) = now.filter(|_| matches!(op, 0x02 | 0x04)) {
+                    let deadline = now.saturating_add(GP1_STATUS_LATCH_CYCLES);
+                    self.pending_gp1_status.push_back((deadline, value));
+                } else {
+                    self.apply_gp1_status(value);
+                }
                 true
             }
             _ => false,
+        }
+    }
+
+    fn apply_gp1_status(&mut self, value: u32) {
+        if value >> 24 == 0x1f {
+            self.status.raw |= 1 << 24;
+            self.irq_requested = true;
+            return;
+        }
+        if matches!((value >> 24) & 0xFF, 0x00 | 0x02) {
+            self.irq_acknowledged = true;
+        }
+        self.status.gp1_write(value);
+    }
+
+    fn apply_pending_gp1_status(&mut self, now: u64) {
+        while self
+            .pending_gp1_status
+            .front()
+            .is_some_and(|(deadline, _)| *deadline <= now)
+        {
+            let (_, value) = self
+                .pending_gp1_status
+                .pop_front()
+                .expect("front was present");
+            self.apply_gp1_status(value);
         }
     }
 
@@ -1600,6 +1686,7 @@ impl Gpu {
     /// and drawing-offset because the rasterizer needs them.
     fn execute_gp0_single(&mut self, word: u32) {
         let op = (word >> 24) & 0xFF;
+        let timing_cost = self.gp0_packet_timing_cost(op as u8);
         // Pixel tracer also wants to see state-modifying single-word
         // packets (0xE1..=0xE6 draw-mode / tex-window / draw-area /
         // draw-offset / mask). These don't plot pixels but they shift
@@ -1727,6 +1814,13 @@ impl Gpu {
                 self.tex_window_offset_y = (((word >> 15) & 0x1F) as u8) << 3;
             }
             _ => {}
+        }
+        if op == 0x1F {
+            // IRQ1 occupies the shared GP0 input path, so GPUSTAT.28 drops
+            // with command-ready even when the command came from the CPU.
+            self.charge_dma_busy(timing_cost);
+        } else {
+            self.charge_busy(timing_cost);
         }
     }
 

--- a/emu/crates/emulator-core/src/gpu/tests.rs
+++ b/emu/crates/emulator-core/src/gpu/tests.rs
@@ -111,6 +111,32 @@ fn gp0_irq_request_and_gp1_ack_toggle_gpustat_bit() {
 }
 
 #[test]
+fn gp1_status_changes_land_between_first_and_second_reads() {
+    let mut gpu = Gpu::new();
+    gpu.write32_at(GP1_ADDR, 0x0400_0001, 100);
+    assert_eq!((gpu.read32_at(GP1_ADDR, 106).unwrap() >> 29) & 3, 0);
+    assert_eq!((gpu.read32_at(GP1_ADDR, 112).unwrap() >> 29) & 3, 1);
+
+    gpu.write32(GP0_ADDR, 0x1f00_0000);
+    gpu.write32_at(GP1_ADDR, 0x0200_0000, 200);
+    assert_ne!(gpu.read32_at(GP1_ADDR, 206).unwrap() & (1 << 24), 0);
+    assert_eq!(gpu.read32_at(GP1_ADDR, 212).unwrap() & (1 << 24), 0);
+    assert!(gpu.take_irq_acknowledged());
+    gpu.decay_busy(u64::MAX);
+
+    gpu.write32_at(GP0_ADDR, 0x1f00_0000, 300);
+    let first = gpu.read32_at(GP1_ADDR, 306).unwrap();
+    assert_eq!(first & (1 << 24), 0);
+    assert_eq!(first & ((1 << 26) | (1 << 28)), 0);
+    assert_ne!(first & (1 << 25), 0);
+    gpu.decay_busy(GP1_STATUS_LATCH_CYCLES);
+    let second = gpu.read32_at(GP1_ADDR, 312).unwrap();
+    assert_ne!(second & (1 << 24), 0);
+    assert_eq!(second & ((1 << 26) | (1 << 28)), (1 << 26) | (1 << 28));
+    assert!(gpu.take_irq_requested());
+}
+
+#[test]
 fn gp1_display_disable_toggles_bit_23() {
     let mut gpu = Gpu::new();
     // Start disabled (reset state has bit 23 set).

--- a/emu/crates/emulator-core/src/spu.rs
+++ b/emu/crates/emulator-core/src/spu.rs
@@ -847,6 +847,17 @@ pub struct Spu {
     /// SPU status register (0x1F80_1DAE). Lower 6 bits mirror SPUCNT.
     /// Bit 6 = IRQ-triggered latch (cleared by SPUCNT write with bit 6 clear).
     spustat: u16,
+    /// Applied and pending copies of SPUSTAT's low-six-bit SPUCNT mirror.
+    /// Silicon updates this mirror on the next 44.1 kHz sample boundary,
+    /// independently from the immediately-readable SPUCNT write latch.
+    #[serde(default)]
+    spustat_control: u16,
+    #[serde(default)]
+    spustat_control_pending: Option<(u16, u64)>,
+    /// DMA request bits 7..9 are asserted only while channel 4 is actively
+    /// transferring, not merely because SPUCNT selects a DMA mode.
+    #[serde(default)]
+    dma_active: bool,
     /// IRQ address (byte addr into SPU RAM). Written as halfword value
     /// which is scaled by 8.
     irq_addr: u32,
@@ -1051,6 +1062,9 @@ impl Spu {
             voices: std::array::from_fn(|_| Voice::default()),
             spucnt: 0,
             spustat: 0,
+            spustat_control: 0,
+            spustat_control_pending: None,
+            dma_active: false,
             irq_addr: 0,
             transfer_addr: 0,
             transfer_addr_raw: 0,
@@ -1197,19 +1211,49 @@ impl Spu {
     /// DMA-request bits synthesised from the SPUCNT transfer mode, and
     /// bit 11 (capture-buffer half) is held in `self.spustat`.
     pub fn spustat(&self) -> u16 {
+        self.spustat_at(u64::MAX)
+    }
+
+    /// SPUSTAT sampled at a CPU cycle. The low control mirror crosses into
+    /// the status domain at the next SPU sample edge.
+    pub fn spustat_at(&self, now: u64) -> u16 {
         // Bits 0..5 mirror SPUCNT; bits 6/10/11 are held in self.spustat
         // (IRQ latch / transfer-busy / capture-buffer half).
-        let mut s = (self.spustat & !0x3F) | (self.spucnt & 0x3F);
+        let control = match self.spustat_control_pending {
+            Some((value, deadline)) if deadline <= now => value,
+            _ => self.spustat_control,
+        };
+        let mut s = (self.spustat & !0x3F) | control;
         // DMA-request status bits (PSX-SPX SPUSTAT): bit 7 = DMA
         // read/write request (mirrors SPUCNT bit 5, i.e. set for both
         // DMA transfer modes), bit 8 = DMA write request (transfer
         // mode 2), bit 9 = DMA read request (transfer mode 3).
-        match (self.spucnt >> 4) & 3 {
-            2 => s |= (1 << 7) | (1 << 8),
-            3 => s |= (1 << 7) | (1 << 9),
+        match ((self.spucnt >> 4) & 3, self.dma_active) {
+            (2, true) => s |= (1 << 7) | (1 << 8),
+            (3, true) => s |= (1 << 7) | (1 << 9),
             _ => {}
         }
         s
+    }
+
+    /// Mark DMA channel 4 as owning the SPU transfer engine.
+    pub fn begin_dma(&mut self, now: u64) {
+        self.dma_active = true;
+        // DMA-read mode's control mirror is gated by ownership of the
+        // transfer engine on SCPH-9902. Once channel 4 is armed it crosses at
+        // the normal sample boundary, just like the other control modes.
+        if (self.spucnt >> 4) & 3 == 3 {
+            let next_sample = now
+                .saturating_div(SAMPLE_CYCLES)
+                .saturating_add(1)
+                .saturating_mul(SAMPLE_CYCLES);
+            self.spustat_control_pending = Some((self.spucnt & 0x3F, next_sample));
+        }
+    }
+
+    /// Release the SPU transfer engine when the scheduled DMA completes.
+    pub fn end_dma(&mut self) {
+        self.dma_active = false;
     }
 
     /// Diagnostic: total samples produced since reset. One sample pair
@@ -1345,7 +1389,7 @@ impl Spu {
     }
 
     /// 16-bit read with cycle context.
-    pub fn read16_at(&self, phys: u32, _now: u64) -> u16 {
+    pub fn read16_at(&self, phys: u32, now: u64) -> u16 {
         let phys = phys & !1;
         if let Some((v, off)) = decode_voice(phys) {
             return self.read_voice_reg(v, off);
@@ -1375,7 +1419,7 @@ impl Spu {
             TRANSFER_FIFO => self.transfer_fifo_read(),
             SPUCNT => self.spucnt,
             TRANSFER_CTRL => self.transfer_ctrl,
-            SPUSTAT => self.spustat(),
+            SPUSTAT => self.spustat_at(now),
             CD_VOL_L => self.cd_vol_l.reg_read(),
             CD_VOL_R => self.cd_vol_r.reg_read(),
             EXT_VOL_L => self.ext_vol_l.reg_read(),
@@ -1394,7 +1438,7 @@ impl Spu {
     }
 
     /// 16-bit write with cycle context.
-    pub fn write16_at(&mut self, phys: u32, value: u16, _now: u64) {
+    pub fn write16_at(&mut self, phys: u32, value: u16, now: u64) {
         let phys = phys & !1;
         if let Some((v, off)) = decode_voice(phys) {
             self.write_voice_reg(v, off, value);
@@ -1426,7 +1470,7 @@ impl Spu {
                 self.transfer_addr = (value as u32) << 3;
             }
             TRANSFER_FIFO => self.transfer_fifo_write(value),
-            SPUCNT => self.write_spucnt(value),
+            SPUCNT => self.write_spucnt(value, now),
             TRANSFER_CTRL => self.transfer_ctrl = value,
             SPUSTAT => { /* read-only -- writes dropped */ }
             CD_VOL_L => self.cd_vol_l.write_signed_q15(value),
@@ -1473,9 +1517,25 @@ impl Spu {
         }
     }
 
-    fn write_spucnt(&mut self, value: u16) {
+    fn write_spucnt(&mut self, value: u16, now: u64) {
         let prev = self.spucnt;
+        if let Some((pending, deadline)) = self.spustat_control_pending {
+            if deadline <= now {
+                self.spustat_control = pending;
+                self.spustat_control_pending = None;
+            }
+        }
         self.spucnt = value;
+        // DMA-read mode does not become the current SPUSTAT mode merely from
+        // the control write: SCPH-9902 stayed in Stop for all 65,535 polls
+        // before channel 4 was armed. Other modes cross at the next sample.
+        if (value >> 4) & 3 != 3 {
+            let next_sample = now
+                .saturating_div(SAMPLE_CYCLES)
+                .saturating_add(1)
+                .saturating_mul(SAMPLE_CYCLES);
+            self.spustat_control_pending = Some((value & 0x3F, next_sample));
+        }
         // SPU IRQ enable transitioned to 0 → clear status latch (ack).
         if (prev & (1 << 6)) != 0 && (value & (1 << 6)) == 0 {
             self.spustat &= !(1 << 6);
@@ -1935,6 +1995,12 @@ impl Spu {
     /// amortise voice-state fetches across several samples).
     pub fn tick_sample(&mut self, now: u64) -> usize {
         self.last_sample_cycle = now;
+        if let Some((pending, deadline)) = self.spustat_control_pending {
+            if deadline <= now {
+                self.spustat_control = pending;
+                self.spustat_control_pending = None;
+            }
+        }
         // KON / KOFF are applied at the END of this tick (after the
         // sample is emitted), not here -- see the apply_kon_koff() call
         // below. PSX-SPX runs update_keystatus() after push_sample

--- a/emu/crates/emulator-core/src/spu/tests.rs
+++ b/emu/crates/emulator-core/src/spu/tests.rs
@@ -2059,6 +2059,8 @@ fn spustat_exposes_dma_request_bits_from_transfer_mode() {
     let mut s = Spu::new();
 
     s.write16(SPUCNT, 2 << 4); // DMA write mode
+    assert_eq!(s.spustat() & 0x0380, 0, "mode alone does not request DMA");
+    s.begin_dma(0);
     assert_ne!(
         s.spustat() & (1 << 7),
         0,
@@ -2104,6 +2106,35 @@ fn spustat_exposes_dma_request_bits_from_transfer_mode() {
         0,
         "Manual-Write mode sets no DMA request bits"
     );
+    s.end_dma();
+}
+
+#[test]
+fn spustat_control_mirror_updates_on_next_sample_boundary() {
+    let mut s = Spu::new();
+    s.write16_at(SPUCNT, 0x002f, 100);
+
+    assert_eq!(s.spucnt(), 0x002f, "SPUCNT write latch is immediate");
+    assert_eq!(
+        s.spustat_at(767) & 0x3f,
+        0,
+        "mirror remains old before edge"
+    );
+    assert_eq!(s.spustat_at(768) & 0x3f, 0x2f, "mirror lands at edge");
+
+    s.tick_sample(768);
+    assert_eq!(s.spustat_control, 0x2f);
+}
+
+#[test]
+fn dma_read_control_mirror_waits_for_channel_arm() {
+    let mut s = Spu::new();
+    s.write16_at(SPUCNT, 0x0030, 100);
+    assert_eq!(s.spustat_at(10_000) & 0x3f, 0);
+
+    s.begin_dma(10_000);
+    assert_eq!(s.spustat_at(10_751) & 0x3f, 0);
+    assert_eq!(s.spustat_at(10_752) & 0x3f, 0x30);
 }
 
 #[test]

--- a/sdk/crates/psx-gte-core/src/state.rs
+++ b/sdk/crates/psx-gte-core/src/state.rs
@@ -164,6 +164,11 @@ pub struct Gte {
     /// into the next MVMVA.
     #[cfg_attr(feature = "serde", serde(skip))]
     stale_v0x: Option<i16>,
+    /// OP counterpart to `stale_v0x`: only its first MAC row sees the IR3
+    /// value that preceded an immediately adjacent MTC2 IR3. Later rows see
+    /// the committed value. Transient and one-shot for the same reason.
+    #[cfg_attr(feature = "serde", serde(skip))]
+    stale_op_ir3: Option<i16>,
 
     // Control registers -------------------------------------------------
     /// Rotation matrix RT, signed 1.3.12.
@@ -292,6 +297,7 @@ impl Gte {
             lzcs: 0,
             lzcr: 0,
             stale_v0x: None,
+            stale_op_ir3: None,
             rotation: [[0; 3]; 3],
             translation: [0; 3],
             light: [[0; 3]; 3],
@@ -578,6 +584,14 @@ impl Gte {
         self.stale_v0x = None;
     }
 
+    /// Execute OP with an MTC2 IR3 value still committing during its first
+    /// sequential MAC row. MAC1 sees `stale_ir3`; MAC2/MAC3 see current IR3.
+    pub fn execute_op_with_stale_ir3(&mut self, instr: u32, stale_ir3: i16) {
+        self.stale_op_ir3 = Some(stale_ir3);
+        self.execute(instr);
+        self.stale_op_ir3 = None;
+    }
+
     /// Execute one COP2 function. `instr` is the full 32-bit
     /// instruction word so we can pull `sf`/`lm`/`mx`/`vx`/`cv`.
     /// Unrecognised commands return without updating state -- real
@@ -730,7 +744,8 @@ impl Gte {
         let ir1 = self.ir[0] as i64;
         let ir2 = self.ir[1] as i64;
         let ir3 = self.ir[2] as i64;
-        let mac1 = self.check_mac(1, (ir3 * d2) - (ir2 * d3)) >> sf;
+        let ir3_mac1 = i64::from(self.stale_op_ir3.unwrap_or(self.ir[2]));
+        let mac1 = self.check_mac(1, (ir3_mac1 * d2) - (ir2 * d3)) >> sf;
         let mac2 = self.check_mac(2, (ir1 * d3) - (ir3 * d1)) >> sf;
         let mac3 = self.check_mac(3, (ir2 * d1) - (ir1 * d2)) >> sf;
         self.mac[0] = mac1 as i32;


### PR DESCRIPTION
## Summary

- replace the fixed NCLIP delay with the SXY/RTPT pipeline history measured on PAL SCPH-9902 hardware
- model the measured LZCR, OP input, and MAC write-port hazards
- delay GPUSTAT-visible IRQ acknowledge/request and DMA-direction changes to the captured latch edge
- move the SPUSTAT control mirror to the SPU sample boundary and expose DMA request bits only while channel 4 is active
- route GPU/SPU MMIO and SPU DMA completion through cycle-aware bus paths

## Validation

- `cargo test --lib --quiet` in `emu/crates/emulator-core`: 504 passed
- `cargo test --lib --quiet` in `sdk/crates/psx-gte-core`: 58 passed
- scoped rustfmt checks passed for both changed packages
- emulator-core clippy passed after excluding pre-existing warnings outside this change
- final headless hardware-test replay completed at 160,000,000 steps with stable timing-map hash `0x0BD32449`
- all captured NCLIP, OP, LZCR, GPUSTAT-transition, and 128 GTE precision values match the final real-hardware capture
