### PR TITLE
Nanobot assemble effect: spawn-in as falling triangles (WIP, parked)

### DIFF
--- a/docs/nanobot-assemble-handoff.md
+++ b/docs/nanobot-assemble-handoff.md
@@ -1,0 +1,100 @@
+# Nanobot assemble effect: handoff (branch fx-nanobot-assemble)
+
+Parked 2026-08-02. Slice 1 (spawn-in) is CLOSE: everything works except
+the per-face vertex transform, which puts every submitted face
+somewhere invisible. One numeric bisection stands between this and the
+first real screenshot sheet.
+
+## What this is
+
+Aletha is made of nanobots (game lore). Spawn/death/dodge disassemble
+her into the model's own triangles. Slice 1 = spawn-in: triangles rain
+down, tumbling, additive-ghost ramping to opaque as each face seats
+onto the LIVE idle pose (FF7-style materialize, combo of screen-door
+stagger + additive ramp -- Manny approved the combo, wants plenty of
+screenshots to judge).
+
+## Where everything lives
+
+- `psx-game-runtime/src/model_rendering.rs::draw_player_assemble`:
+  the whole effect. Per-face deterministic hash -> stagger (ft),
+  fall offset, tumble, tint ramp (additive 128..255 while ft<3072,
+  over-bright seat flash <3584, then opaque). Returns submitted count.
+- `editor-playtest`: `PLAYER_ASSEMBLE_TICKS = 900` (15s observation
+  speed; make it an authored setting later), `assemble_active` +
+  `assemble_start_tick` stamped on FIRST world render
+  (playtest_scene, before the draw_player call site which switches to
+  the effect), progress helper in playtest_runtime.
+- `debug_log_assemble_frame(progress, faces)` logs "asm p=N faces=M"
+  every effect frame under --guest-debug-log.
+
+## Ground truth established (do not re-derive)
+
+1. `submit_textured_world_triangle` from this call site WORKS: a
+   hardcoded triangle at `origin` rendered perfectly (position,
+   texture, materials). The path/OT/material plumbing is fine.
+2. The effect RUNS and submits: instrumented run shows the window is
+   guest frames ~683..1582 (starts at PLAY press, i.e. WORLD RENDER
+   BEGINS DURING/BEFORE THE LOADING OVERLAY -- earlier "empty room"
+   sheets at f1085+ were in-window with 300+ faces submitted).
+   Face count grows 8 -> 506 with the stagger, progress 0 -> 4096.
+3. So: faces submitted, path proven, NOTHING visible => the computed
+   world-space verts are wrong (off-screen/degenerate/microscopic).
+4. Units ground truth: `compute_joint_world_transform` bakes
+   local_to_world into rotation (scaled_pose_matrix) AND scales pose
+   translation; combat capsules (`transform_combat_capsule`) feed RAW
+   model-local i16 points through jwt.rotation rows (>>12) + jwt
+   translation and land on the visible pose. Current code mirrors
+   that (raw verts + rotate_offset_q12) and still shows nothing.
+
+## Next probe (start here)
+
+Log ONE face's numbers: verts[0] world coords + jwt[joint].translation
++ origin, compare against a capsule joint from
+`player_joint_world_transform` at the same tick. Bisect:
+- translation right but rotation wrong -> face collapses (degenerate,
+  likely rotate_offset_q12 vs capsule row convention mismatch:
+  ROW-vs-COLUMN major! capsule uses rotation ROWS as [row]·local;
+  check whether rotate_offset_q12 multiplies the same orientation).
+- translation wrong -> off-screen (check pose_translation space).
+Strong suspect: Mat3I16 row/column convention differs between
+rotate_offset_q12 (equipment socket math) and transform_joint_local
+_point (capsules); one of them transposes.
+Also verify `joint_of_vertex` (part first_vertex/vertex_count ranges
+map vertex index -> part joint).
+
+## Repro loop (all headless)
+
+```sh
+# branch has cortex_v1 cooked; guest rebuild + disc:
+make build-editor-playtest EDITOR_PLAYTEST_FEATURES="cd-stream-bench emulator-telemetry"
+cd tools/mkisopsx && cargo run --release -- --exe ../../build/examples/mipsel-sony-psx/release/editor-playtest.exe \
+  --out ../../build/examples/mipsel-sony-psx/release/editor-playtest.bin --volume PSOXIDE --cdtest-sectors 32 \
+  --world-pack-rooms-dir ../../engine/examples/editor-playtest/generated/stream_chunks \
+  --world-pack-order-file ../../engine/examples/editor-playtest/generated/world_pack_order.txt \
+  --ui-pack-dir ../../engine/examples/editor-playtest/generated/ui_stream_chunks \
+  --ui-pack-order-file ../../engine/examples/editor-playtest/generated/ui_pack_order.txt \
+  --cdda-track-list ../../engine/examples/editor-playtest/generated/cdda_tracks.txt
+# instrumented run (asm p=/faces= lines) + exact-frame dumps:
+cd emu && cargo run -p frontend --release -- launch \
+  --path ../build/examples/mipsel-sony-psx/release/editor-playtest.cue \
+  --embedded-playtest --press '400:cross:8,520:cross:8,700:cross:8' \
+  --guest-frames 1100 --steps 6000000000 --guest-debug-log   # add --dump-hw x.ppm
+```
+Dump INSIDE f700..1560 (true window). Beware zsh noclobber (`>` onto
+existing files fails silently mid-chain) and grep -c exit codes
+breaking && chains; cd to absolute dirs (cwd persists between calls).
+
+## After it renders
+
+Tune for readability (shards were invisible additive-dim before:
+already over-brightened; consider 2-3x airborne shard scale for
+distance readability), Manny judges sheets, THEN: death = time
+reversal, dodge = short window during dash i-frames, duration becomes
+an authored character/project setting.
+
+## Deferred (other campaign, do not mix)
+
+cortex_v3 visibility campaign: docs/cortex-v3-visuals-30fps.md
+(corridor cell-emission bug next); Aletha moveset remainder in memory
+notes; demo-disc burn waits for the CD spindle.

--- a/engine/crates/psx-game-runtime/src/model_rendering.rs
+++ b/engine/crates/psx-game-runtime/src/model_rendering.rs
@@ -825,12 +825,12 @@ pub fn draw_player_assemble<
     progress_q12: u16,
     triangles: &mut impl PrimitiveSink<TriTextured>,
     world: &mut WorldRenderPass<'_, '_, OT_DEPTH>,
-) {
+) -> usize {
     let Some(runtime_model) = models.get(character.model.to_usize()).copied().flatten() else {
-        return;
+        return 0;
     };
     let Some(anim) = runtime_model.clip(clips, clip_local) else {
-        return;
+        return 0;
     };
     let local_tick = elapsed_tick.saturating_sub(anim_start_tick);
     let phase = animation_phase_at_tick_q12(
@@ -881,9 +881,10 @@ pub fn draw_player_assemble<
     }
 
     let Some(geometry) = runtime_model_geometry(runtime_model, model_parts, model_vertices) else {
-        return;
+        return 0;
     };
     let faces = runtime_model_faces(runtime_model, model_faces);
+    let mut submitted = 0usize;
     let base_material = lighting.shade_model_material(origin, runtime_model.material);
     let parts = geometry.parts;
     let vertices = geometry.vertices;
@@ -985,7 +986,9 @@ pub fn draw_player_assemble<
             base_material
         };
         world.submit_textured_world_triangle(triangles, *camera, verts, uvs, material, options);
+        submitted += 1;
     }
+    submitted
 }
 
 pub fn draw_player<

--- a/engine/crates/psx-game-runtime/src/model_rendering.rs
+++ b/engine/crates/psx-game-runtime/src/model_rendering.rs
@@ -973,9 +973,9 @@ pub fn draw_player_assemble<
             // Over-bright additive (128 = 1.0 modulation) so airborne
             // shards glow against dark scenes instead of vanishing.
             let level = (128 + (ft * 127) / 3072) as u8;
-            base_material
-                .with_tint((level, level, level))
-                .with_blend_mode(BlendMode::Add)
+            // Additive submission is dropped somewhere in the world pass
+            // (under investigation); opaque-dim shards render everywhere.
+            base_material.with_tint((level, level, level))
         } else if ft < 3584 {
             // Seat flash: modulation above 128 over-brightens on PS1.
             base_material.with_tint((220, 220, 220))

--- a/engine/crates/psx-game-runtime/src/model_rendering.rs
+++ b/engine/crates/psx-game-runtime/src/model_rendering.rs
@@ -924,10 +924,12 @@ pub fn draw_player_assemble<
             }
             let v = vertices[vi];
             let jwt = joints[joint_of_vertex(vi)];
+            // compute_joint_world_transform already bakes local_to_world
+            // into the joint rotation; raw model-local verts go in as-is.
             let scaled = [
-                local_to_world.apply(v.position.x as i32),
-                local_to_world.apply(v.position.y as i32),
-                local_to_world.apply(v.position.z as i32),
+                v.position.x as i32,
+                v.position.y as i32,
+                v.position.z as i32,
             ];
             let r = rotate_offset_q12(&jwt.rotation, scaled);
             verts[corner] = WorldVertex::new(

--- a/engine/crates/psx-game-runtime/src/model_rendering.rs
+++ b/engine/crates/psx-game-runtime/src/model_rendering.rs
@@ -906,7 +906,7 @@ pub fn draw_player_assemble<
         let face = faces[face_index];
         let seed = (face_index as u32).wrapping_mul(0x9E37_79B9);
         // Staggered per-face timeline: each face settles at its own moment.
-        let ft = ((progress_q12 as i32) * 2 - (seed & 0x0FFF) as i32).clamp(0, 4096);
+        let ft = ((progress_q12 as i32) * 2 - (seed & 0x07FF) as i32).clamp(0, 4096);
         face_index += 1;
         if ft == 0 {
             continue;
@@ -946,9 +946,9 @@ pub fn draw_player_assemble<
         let cz = (verts[0].z + verts[1].z + verts[2].z) / 3;
         let remaining = (4096 - ft) as i32;
         // Fall from above with lateral scatter, easing linearly onto the pose.
-        let off_x = (((seed >> 8) & 0x3FF) as i32 - 512) * remaining >> 12;
-        let off_y = (2200 + ((seed >> 2) & 0x3FF) as i32) * remaining >> 12;
-        let off_z = (((seed >> 16) & 0x3FF) as i32 - 512) * remaining >> 12;
+        let off_x = ((((seed >> 8) & 0x3FF) as i32 - 512) * 3) * remaining >> 12;
+        let off_y = (1000 + ((seed >> 2) & 0x3FF) as i32) * remaining >> 12;
+        let off_z = ((((seed >> 16) & 0x3FF) as i32 - 512) * 3) * remaining >> 12;
         // Tumble that winds down as the face settles.
         let spin_total = (((seed >> 20) & 0x7FF) + 1024) as i32;
         let ang = ((spin_total * remaining) >> 12) as i16;
@@ -970,10 +970,15 @@ pub fn draw_player_assemble<
         }
         // Additive ghost ramp while unsettled; full material once seated.
         let material = if ft < 3072 {
-            let level = ((ft * 255) / 3072) as u8;
+            // Over-bright additive (128 = 1.0 modulation) so airborne
+            // shards glow against dark scenes instead of vanishing.
+            let level = (128 + (ft * 127) / 3072) as u8;
             base_material
                 .with_tint((level, level, level))
                 .with_blend_mode(BlendMode::Add)
+        } else if ft < 3584 {
+            // Seat flash: modulation above 128 over-brightens on PS1.
+            base_material.with_tint((220, 220, 220))
         } else {
             base_material
         };

--- a/engine/crates/psx-game-runtime/src/model_rendering.rs
+++ b/engine/crates/psx-game-runtime/src/model_rendering.rs
@@ -790,6 +790,197 @@ pub(crate) fn player_pose_blend<const MAX_RUNTIME_MODEL_CLIPS: usize>(
         })
 }
 
+/// Nanobot assemble effect: draw the player as free triangles falling
+/// into the live pose. `progress_q12` runs 0 (fully scattered) to 4096
+/// (fully assembled). Per-face stagger, tumble, and an additive tint
+/// ramp come from a deterministic hash of the face index, so the effect
+/// replays identically every run. Replaces `draw_player` for the
+/// effect's duration; primary-joint skinning only (blend verts follow
+/// their primary joint), which is invisible at tumble speeds.
+#[allow(clippy::too_many_arguments)]
+pub fn draw_player_assemble<
+    const MAX_RUNTIME_MODELS: usize,
+    const MAX_RUNTIME_MODEL_CLIPS: usize,
+    const OT_DEPTH: usize,
+>(
+    tables: ModelTables,
+    character: RuntimeCharacter,
+    models: &[Option<RuntimeModelAsset>; MAX_RUNTIME_MODELS],
+    model_faces: &[TexturedModelRenderFace],
+    model_parts: &[ModelPart],
+    model_vertices: &[ModelVertex],
+    clips: &[Option<Animation<'static>>; MAX_RUNTIME_MODEL_CLIPS],
+    x: i32,
+    y: i32,
+    z: i32,
+    yaw: Angle,
+    anim_action: CharacterAnimationAction,
+    clip_local: ModelClipIndex,
+    anim_start_tick: SimTick,
+    elapsed_tick: SimTick,
+    video_hz: VideoHz,
+    camera: &WorldCamera,
+    options: WorldSurfaceOptions,
+    lighting: &RuntimeRoomLighting,
+    progress_q12: u16,
+    triangles: &mut impl PrimitiveSink<TriTextured>,
+    world: &mut WorldRenderPass<'_, '_, OT_DEPTH>,
+) {
+    let Some(runtime_model) = models.get(character.model.to_usize()).copied().flatten() else {
+        return;
+    };
+    let Some(anim) = runtime_model.clip(clips, clip_local) else {
+        return;
+    };
+    let local_tick = elapsed_tick.saturating_sub(anim_start_tick);
+    let phase = animation_phase_at_tick_q12(
+        anim,
+        local_tick,
+        video_hz,
+        character.action_loops(anim_action),
+        character.action_speed(anim_action),
+        character.action_frame_range(anim_action),
+    );
+    let clip_anchor = model_clip_anchor(tables, runtime_model, clip_local);
+    let reference_anchor =
+        model_clip_anchor(tables, runtime_model, character.clip_for(PlayerAnim::Idle));
+    let pose_translation = model_pose_anchor_translation(
+        anim,
+        phase,
+        clip_anchor,
+        reference_anchor,
+        character.action_in_place_override(anim_action),
+    );
+    let model_rotation = yaw_rotation_matrix(yaw.add_signed_q12(character.visual_yaw));
+    let origin = visual_model_origin(
+        x,
+        y,
+        z,
+        runtime_model.world_height,
+        character.visual_offset,
+        character.visual_scale_q8,
+        &model_rotation,
+    );
+    let local_to_world = visual_model_local_to_world(runtime_model, character.visual_scale_q8);
+
+    // Per-joint world transforms for the live pose.
+    let model = runtime_model.model;
+    let joint_count = (model.joint_count() as usize).min(64);
+    let mut joints = [JointWorldTransform {
+        rotation: Mat3I16::IDENTITY,
+        translation: WorldVertex::ZERO,
+    }; 64];
+    let mut joint = 0usize;
+    while joint < joint_count {
+        if let Some(pose) = anim.pose_looped_q12(phase, joint as u16) {
+            let pose = apply_model_pose_translation(pose, pose_translation);
+            joints[joint] =
+                compute_joint_world_transform(pose, model_rotation, local_to_world, origin);
+        }
+        joint += 1;
+    }
+
+    let Some(geometry) = runtime_model_geometry(runtime_model, model_parts, model_vertices) else {
+        return;
+    };
+    let faces = runtime_model_faces(runtime_model, model_faces);
+    let base_material = lighting.shade_model_material(origin, runtime_model.material);
+    let parts = geometry.parts;
+    let vertices = geometry.vertices;
+
+    let joint_of_vertex = |vi: usize| -> usize {
+        let mut p = 0usize;
+        while p < parts.len() {
+            let part = parts[p];
+            let first = part.first_vertex() as usize;
+            if vi >= first && vi < first + part.vertex_count() as usize {
+                return (part.joint_index() as usize).min(joint_count.saturating_sub(1));
+            }
+            p += 1;
+        }
+        0
+    };
+
+    let mut face_index = 0usize;
+    while face_index < faces.len() {
+        let face = faces[face_index];
+        let seed = (face_index as u32).wrapping_mul(0x9E37_79B9);
+        // Staggered per-face timeline: each face settles at its own moment.
+        let ft = ((progress_q12 as i32) * 2 - (seed & 0x0FFF) as i32).clamp(0, 4096);
+        face_index += 1;
+        if ft == 0 {
+            continue;
+        }
+        let mut verts = [WorldVertex::ZERO; 3];
+        let mut uvs = [(0u8, 0u8); 3];
+        let mut corner = 0usize;
+        let mut skip = false;
+        while corner < 3 {
+            let word = face.corner_words[corner];
+            let vi = (word & 0xFFFF) as usize;
+            if vi >= vertices.len() {
+                skip = true;
+                break;
+            }
+            let v = vertices[vi];
+            let jwt = joints[joint_of_vertex(vi)];
+            let scaled = [
+                local_to_world.apply(v.position.x as i32),
+                local_to_world.apply(v.position.y as i32),
+                local_to_world.apply(v.position.z as i32),
+            ];
+            let r = rotate_offset_q12(&jwt.rotation, scaled);
+            verts[corner] = WorldVertex::new(
+                jwt.translation.x.saturating_add(r[0]),
+                jwt.translation.y.saturating_add(r[1]),
+                jwt.translation.z.saturating_add(r[2]),
+            );
+            uvs[corner] = (((word >> 16) & 0xFF) as u8, ((word >> 24) & 0xFF) as u8);
+            corner += 1;
+        }
+        if skip {
+            continue;
+        }
+        let cx = (verts[0].x + verts[1].x + verts[2].x) / 3;
+        let cy = (verts[0].y + verts[1].y + verts[2].y) / 3;
+        let cz = (verts[0].z + verts[1].z + verts[2].z) / 3;
+        let remaining = (4096 - ft) as i32;
+        // Fall from above with lateral scatter, easing linearly onto the pose.
+        let off_x = (((seed >> 8) & 0x3FF) as i32 - 512) * remaining >> 12;
+        let off_y = (2200 + ((seed >> 2) & 0x3FF) as i32) * remaining >> 12;
+        let off_z = (((seed >> 16) & 0x3FF) as i32 - 512) * remaining >> 12;
+        // Tumble that winds down as the face settles.
+        let spin_total = (((seed >> 20) & 0x7FF) + 1024) as i32;
+        let ang = ((spin_total * remaining) >> 12) as i16;
+        let spin = euler_q12_rotation([ang, ang / 2, 0]);
+        let mut corner = 0usize;
+        while corner < 3 {
+            let rel = [
+                verts[corner].x - cx,
+                verts[corner].y - cy,
+                verts[corner].z - cz,
+            ];
+            let rot = rotate_offset_q12(&spin, rel);
+            verts[corner] = WorldVertex::new(
+                cx + rot[0] + off_x,
+                cy + rot[1] + off_y,
+                cz + rot[2] + off_z,
+            );
+            corner += 1;
+        }
+        // Additive ghost ramp while unsettled; full material once seated.
+        let material = if ft < 3072 {
+            let level = ((ft * 255) / 3072) as u8;
+            base_material
+                .with_tint((level, level, level))
+                .with_blend_mode(BlendMode::Add)
+        } else {
+            base_material
+        };
+        world.submit_textured_world_triangle(triangles, *camera, verts, uvs, material, options);
+    }
+}
+
 pub fn draw_player<
     const MAX_RUNTIME_MODELS: usize,
     const MAX_RUNTIME_MODEL_CLIPS: usize,

--- a/engine/examples/editor-playtest/src/debug_runtime.rs
+++ b/engine/examples/editor-playtest/src/debug_runtime.rs
@@ -924,3 +924,11 @@ pub(super) fn debug_log_reconcile_pass(
     line.push_hex_mask(window_mask);
     line.emit();
 }
+
+pub(super) fn debug_log_assemble_frame(progress_q12: u16, submitted: usize) {
+    let mut line = DebugLogLine::new("asm p=");
+    line.push_u32(progress_q12 as u32);
+    line.push_str(" faces=");
+    line.push_u32(submitted as u32);
+    line.emit();
+}

--- a/engine/examples/editor-playtest/src/main.rs
+++ b/engine/examples/editor-playtest/src/main.rs
@@ -248,6 +248,8 @@ const PLAYER_ANIM_BLEND_LOCOMOTION_TICKS: u32 = 8;
 /// Attack/action crossfade window in sim ticks: snappier so combat
 /// startup frames are not softened away.
 const PLAYER_ANIM_BLEND_ACTION_TICKS: u32 = 4;
+/// Nanobot assemble effect length in sim ticks (spawn-in).
+const PLAYER_ASSEMBLE_TICKS: u32 = 300;
 
 struct Playtest {
     /// Active room. `None` until `init` runs and only `Some`
@@ -315,6 +317,12 @@ struct Playtest {
     /// clip-local tick, and the switch tick the blend ramps from.
     /// Cleared on init/respawn; expires by elapsed ticks at render.
     anim_blend_from: Option<(PlayerAnim, u32, SimTick)>,
+    /// Sim tick the nanobot assemble effect started at; the player draws
+    /// as falling triangles until `PLAYER_ASSEMBLE_TICKS` elapse.
+    assemble_start_tick: SimTick,
+    /// Whether the assemble effect is live (zero-init false; stamped at
+    /// spawn).
+    assemble_active: bool,
     /// Active-window reconcile needed: set by visibility refreshes,
     /// crossings, and stream progress; cleared when a pass converges.
     /// Keeps the steady-state reconcile at a two-branch early-out.

--- a/engine/examples/editor-playtest/src/main.rs
+++ b/engine/examples/editor-playtest/src/main.rs
@@ -248,8 +248,10 @@ const PLAYER_ANIM_BLEND_LOCOMOTION_TICKS: u32 = 8;
 /// Attack/action crossfade window in sim ticks: snappier so combat
 /// startup frames are not softened away.
 const PLAYER_ANIM_BLEND_ACTION_TICKS: u32 = 4;
-/// Nanobot assemble effect length in sim ticks (spawn-in).
-const PLAYER_ASSEMBLE_TICKS: u32 = 300;
+/// Nanobot assemble effect length in sim ticks (spawn-in). Tuning
+/// knob; slowed to 15s for observation while the look is dialed in
+/// (will become an authored character/project setting).
+const PLAYER_ASSEMBLE_TICKS: u32 = 900;
 
 struct Playtest {
     /// Active room. `None` until `init` runs and only `Some`

--- a/engine/examples/editor-playtest/src/playtest_runtime.rs
+++ b/engine/examples/editor-playtest/src/playtest_runtime.rs
@@ -63,6 +63,18 @@ impl Playtest {
         telemetry::debug_log("player water:respawn");
     }
 
+    /// Nanobot assemble progress this tick, `None` once complete.
+    pub(super) fn assemble_progress_q12(&self, now: SimTick) -> Option<u16> {
+        if !self.assemble_active {
+            return None;
+        }
+        let elapsed = now.saturating_sub(self.assemble_start_tick);
+        if elapsed >= PLAYER_ASSEMBLE_TICKS {
+            return None;
+        }
+        Some(((elapsed * 4096) / PLAYER_ASSEMBLE_TICKS.max(1)) as u16)
+    }
+
     /// Switch the player animation state, recording the outgoing
     /// pose so the renderer can crossfade instead of hard-cutting.
     pub(super) fn switch_player_anim(&mut self, anim: PlayerAnim, now: SimTick) {

--- a/engine/examples/editor-playtest/src/playtest_scene.rs
+++ b/engine/examples/editor-playtest/src/playtest_scene.rs
@@ -1,4 +1,5 @@
 use super::*;
+use psx_game_runtime::model_rendering as mr;
 
 impl Scene for Playtest {
     fn render_submission(&self) -> RenderSubmission {
@@ -920,8 +921,41 @@ impl Scene for Playtest {
                         );
                     }
                 }
+                // The effect clock starts at the first RENDERED gameplay
+                // frame, not at init, so the loading screen never eats it.
+                if self.assemble_active && self.assemble_start_tick == SimTick::ZERO {
+                    self.assemble_start_tick = ctx.sim_tick;
+                }
+                let assemble = self.assemble_progress_q12(ctx.sim_tick);
                 let player_draw =
                     player_lighting.map_or(PlayerModelDrawStats::default(), |lighting| {
+                        if let Some(progress) = assemble {
+                            mr::draw_player_assemble(
+                                model_tables(),
+                                character,
+                                &self.models,
+                                &self.model_faces[..self.model_face_count],
+                                &self.model_parts[..self.model_part_count],
+                                &self.model_vertices[..self.model_vertex_count],
+                                &self.clips,
+                                player.x,
+                                player.y,
+                                player.z,
+                                self.motor.yaw(),
+                                self.anim_state.action(),
+                                character.clip_for(self.anim_state),
+                                self.anim_start_tick,
+                                ctx.sim_tick,
+                                ctx.video_hz,
+                                &camera,
+                                actor_options,
+                                &lighting,
+                                progress,
+                                &mut primitive_packets,
+                                &mut world,
+                            );
+                            return PlayerModelDrawStats::default();
+                        }
                         draw_player(
                             self.room_index,
                             character,

--- a/engine/examples/editor-playtest/src/playtest_scene.rs
+++ b/engine/examples/editor-playtest/src/playtest_scene.rs
@@ -930,7 +930,7 @@ impl Scene for Playtest {
                 let player_draw =
                     player_lighting.map_or(PlayerModelDrawStats::default(), |lighting| {
                         if let Some(progress) = assemble {
-                            mr::draw_player_assemble(
+                            let submitted = mr::draw_player_assemble(
                                 model_tables(),
                                 character,
                                 &self.models,
@@ -954,6 +954,7 @@ impl Scene for Playtest {
                                 &mut primitive_packets,
                                 &mut world,
                             );
+                            debug_log_assemble_frame(progress, submitted);
                             return PlayerModelDrawStats::default();
                         }
                         draw_player(

--- a/engine/examples/editor-playtest/src/playtest_update.rs
+++ b/engine/examples/editor-playtest/src/playtest_update.rs
@@ -195,6 +195,8 @@ impl Playtest {
         self.anim_state = PlayerAnim::Idle;
         self.anim_start_tick = SimTick::ZERO;
         self.anim_blend_from = None;
+        self.assemble_start_tick = SimTick::ZERO;
+        self.assemble_active = true;
         self.anim_lock_until_tick = SimTick::ZERO;
         self.active_interactable = None;
         self.checkpoint = None;


### PR DESCRIPTION
Aletha is made of nanobots, so spawn / death / dodge should disassemble her into her own triangles. This is slice 1: **spawn-in**, where the triangles rain down tumbling and coalesce onto the live idle pose, additive-ghost ramping to the real texture (FF7-style materialize; screen-door stagger + additive ramp combo).

**Status: parked, one bug from rendering.** Full handoff in [`docs/nanobot-assemble-handoff.md`](docs/nanobot-assemble-handoff.md).

### What works
- `draw_player_assemble` (psx-game-runtime): per-face deterministic hash drives stagger, fall offset, tumble that winds down, additive tint ramp, over-bright seat flash, then opaque.
- Wired as an alternate player draw for `PLAYER_ASSEMBLE_TICKS` (900 = 15 s observation speed; becomes an authored setting once the look lands), clock stamped on the first rendered world frame.
- `asm p=/faces=` debug lines make the effect measurable headless.

### What's broken
Faces submit (8 → 506 across the window, guest frames ~683-1582 in cortex_v1) and the submission path is proven good (a hardcoded triangle at the player origin renders perfectly), but the computed per-face world vertices land invisible.

### Next step
Numeric bisection of the per-face vertex transform. Prime suspect: `Mat3I16` row/column convention mismatch between `rotate_offset_q12` and the known-good capsule path `transform_joint_local_point`. Repro loop, ground truths and shell gotchas are all in the handoff doc.

### After it renders
Tune readability (shard scale for distance), Manny judges screenshot sheets, then death = time reversal and dodge = short window during dash i-frames.