### PR TITLE
perf(engine): stop linking the UI front-end into gameplay-only games

### DIFF
--- a/engine/crates/psx-engine/src/app.rs
+++ b/engine/crates/psx-engine/src/app.rs
@@ -43,7 +43,7 @@ use psx_level::{
 };
 use psx_pad::{enable_analog_port1, poll_port1};
 
-use crate::game_app::{GameApp, GAMEPLAY_ONLY};
+use crate::game_app::GameApp;
 use crate::scene::{Ctx, RenderSubmission, Scene};
 use crate::scheduler::{FrameScheduler, SchedulerAction, SchedulerConfig};
 use crate::telemetry;
@@ -435,14 +435,41 @@ impl App {
     /// }
     /// ```
     pub fn run<S: Scene>(config: Config, scene: &mut S) -> ! {
-        // Auto-wrap the bare gameplay scene in the unified runtime
-        // spine over GAMEPLAY_ONLY. That flow has a single Gameplay
-        // state entered at boot, so `GameApp::init` forwards straight
-        // to `scene.init` and `update`/`render` forward straight to
-        // the scene every tick -- the old one-init-then-loop shape,
-        // plus one already-taken `match` branch. No UI scenes, no
-        // nodes, no options: the front-end arms are dead code on this path.
-        Self::run_with_flow(config, &GAMEPLAY_ONLY, &[], &[], &[], &[], &[], &[], scene)
+        // Drive the gameplay scene directly. It is deliberately NOT
+        // wrapped in `GameApp` over GAMEPLAY_ONLY any more.
+        //
+        // Wrapping cost ~115 KB of code in the linked binary. `GameApp`
+        // holds the flow and the UI tables as *runtime* fields
+        // (`flow: &'static GameFlow`), so the `match` on `flow.states`
+        // is not provably monomorphic: LLVM cannot see that
+        // GAMEPLAY_ONLY never yields `FlowState::UiScene`, and keeps
+        // that arm together with everything it reaches --
+        // `render_ui_scene`, transitions, focus ring, shape nodes,
+        // text paints. The arms were dead in the sense that they never
+        // execute, but they were still linked.
+        //
+        // `run_scheduled` is already generic over `S: Scene`, so the
+        // gameplay scene can be driven without an adapter and the
+        // front-end is never monomorphised at all.
+        //
+        // Behaviour note: `GameApp::init` parks on the built-in loading
+        // screen and defers `gameplay.init` until it has rendered once,
+        // which lets streaming scenes finish boot residency first. This
+        // path calls `init` before the loop instead. Every in-tree
+        // `App::run` caller is a self-contained example or game;
+        // `editor-playtest`, the one streaming consumer, uses
+        // `run_with_flow` and is unaffected.
+        let (mut clock, mut ctx) = Self::boot(config);
+
+        boot_trace("psx-engine: scene init");
+        scene.load_shared_assets(&mut ctx);
+        scene.init(&mut ctx);
+        boot_trace("psx-engine: scene init ok");
+        clock.reset_origin();
+
+        let visual_interval = config.visual_pacing.interval_vblanks();
+        boot_trace("psx-engine: loop");
+        Self::run_scheduled(config, scene, clock, ctx, visual_interval)
     }
 
     /// Run `scene` as the gameplay state of a cooked [`GameFlow`].
@@ -467,10 +494,31 @@ impl App {
         ui_sfx_cues: &'static [LevelUiSfxCueRecord],
         scene: &mut S,
     ) -> ! {
+        let (clock, ctx) = Self::boot(config);
+        Self::run_with_flow_booted(
+            config,
+            flow,
+            scenes,
+            nodes,
+            paints,
+            options,
+            ui_sfx_samples,
+            ui_sfx_cues,
+            scene,
+            clock,
+            ctx,
+        )
+    }
+
+    /// Shared boot: GPU, clock, framebuffer, pad and `Ctx`.
+    ///
+    /// Split out so the gameplay-only path can reuse it without going
+    /// through `GameApp` -- see [`run`](Self::run).
+    fn boot(config: Config) -> (EngineClock, Ctx) {
         boot_trace("psx-engine: run");
         gpu::init(config.video_mode, config.resolution);
         boot_trace("psx-engine: gpu ok");
-        let mut clock = EngineClock::new();
+        let clock = EngineClock::new();
         boot_trace("psx-engine: clock ok");
         let fb = FrameBuffer::new(config.screen_w, config.screen_h);
         gpu::set_draw_area(
@@ -507,6 +555,24 @@ impl App {
         );
         boot_visual_checkpoint(&mut ctx.fb, (200, 96, 0), "02 CTX READY");
 
+        boot_trace("psx-engine: ctx ok");
+        (clock, ctx)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn run_with_flow_booted<S: Scene>(
+        config: Config,
+        flow: &'static GameFlow,
+        scenes: &'static [LevelUiScene],
+        nodes: &'static [LevelUiNodeRecord],
+        paints: &'static [LevelUiPaintRecord],
+        options: &'static [LevelOptionDef],
+        ui_sfx_samples: &'static [LevelUiSfxSampleRecord],
+        ui_sfx_cues: &'static [LevelUiSfxCueRecord],
+        scene: &mut S,
+        mut clock: EngineClock,
+        mut ctx: Ctx,
+    ) -> ! {
         // The wrapper is the Scene the scheduled loop drives: its
         // init/update/render dispatch to the borrowed gameplay scene
         // (or the UI renderer) per flow state.


### PR DESCRIPTION
## The problem

`App::run` wraps the caller's scene in `GameApp` over `GAMEPLAY_ONLY`. That
flow has a single `FlowState::Gameplay` and no UI scenes, so the wrapper's UI
arms never execute — the code comment says as much: *"the front-end arms are
dead code on this path"*.

They never execute, but they are still **linked**.

`GameApp` holds the flow and the UI tables as runtime fields
(`flow: &'static GameFlow`), so the `match` on `flow.states` is not provably
monomorphic. LLVM cannot see that `GAMEPLAY_ONLY` never yields
`FlowState::UiScene`, so it keeps that arm along with everything it reaches:
`render_ui_scene`, the transition overlay, the focus ring, shape nodes, text
paints.

In a symbol dump of a small game, `psx-engine` contributed 118,012 bytes, of
which **115,816 were UI/flow code the game cannot reach**.

## The fix

`run_scheduled` is already generic over `S: Scene`, so the gameplay scene can
be driven with no adapter at all. `App::run` now boots and calls it directly.

The boot sequence is split into `App::boot` so `run_with_flow` keeps using
exactly the same code — it is otherwise untouched.

No new types, no feature flags, no public API change.

## Measured

In-tree examples, `mipsel-sony-psx`, release, LTO on:

| example | before | after | saved |
|---|---:|---:|---:|
| hello-engine | 141,312 | 12,288 | −129,024 |
| showcase-text | 147,456 | 32,768 | −114,688 |
| showcase-3d | 172,032 | 53,248 | −118,784 |
| showcase-model | 522,240 | 409,600 | −112,640 |
| showcase-lights | 149,504 | 28,672 | −120,832 |
| showcase-fog | 151,552 | 38,912 | −112,640 |
| showcase-particles | 149,504 | 26,624 | −122,880 |
| game-pong | 178,176 | 67,584 | −110,592 |
| game-breakout | 237,568 | 129,024 | −108,544 |
| game-invaders | 239,616 | 145,408 | −94,208 |
| game-magikaaaaaarp-pong | 337,920 | 245,760 | −92,160 |
| **total** | **2,426,880** | **1,189,888** | **−1,236,992 (−51%)** |

All eleven build. On a 2 MB console where the executable is loaded whole,
`hello-engine` drops from 6.7% of RAM to 0.6%.

## The one thing to review

There is a behaviour change, and it is the part worth your judgement.

`GameApp::init` parks on the built-in loading screen and defers
`gameplay.init` until it has rendered once, so streaming scenes can finish
boot residency before the first world frame. The direct path calls `init`
before the loop instead.

Why I believe that is safe here: all eleven in-tree `App::run` callers are
self-contained examples and games. `editor-playtest` — the one streaming
consumer — uses `run_with_flow` and is untouched.

If you want that park on this path too, it can be reproduced without pulling
in the UI machinery. Happy to do that instead if you prefer.

## Verification

- `cargo clippy -p psx-engine --all-features`: 7 warnings, **identical with and
  without this change** (all in `classic_affine` / `render3d`).
- `cargo test --workspace` in `engine/`: 141 + 394 pass.
  `render3d::tests::grounding_probe_player_lowest_vertex_matches_reference`
  fails identically with and without this change.
- `rustfmt` on `app.rs`: clean. (`cargo fmt --all --check` reports 34 diffs in
  `editor/` and `emu/` on `main` as well, on `nightly-2026-03-24` — unrelated
  to this change.)
- All eleven examples rebuilt and sized after the final formatting pass.
